### PR TITLE
Phase 5: Codebase indexing with Tree-sitter and LanceDB

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -401,6 +401,21 @@ files = [
 markers = {main = "platform_system == \"Windows\"", dev = "sys_platform == \"win32\""}
 
 [[package]]
+name = "deprecation"
+version = "2.1.0"
+description = "A library to handle automated deprecations"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a"},
+    {file = "deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff"},
+]
+
+[package.dependencies]
+packaging = "*"
+
+[[package]]
 name = "dill"
 version = "0.4.1"
 description = "serialize all of Python"
@@ -1166,6 +1181,76 @@ files = [
 referencing = ">=0.31.0"
 
 [[package]]
+name = "lance-namespace"
+version = "0.5.2"
+description = "Lance Namespace interface and plugin registry"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "lance_namespace-0.5.2-py3-none-any.whl", hash = "sha256:6ccaf5649bf6ee6aa92eed9c535a114b7b4eb08e89f40426f58bc1466cbcffa3"},
+    {file = "lance_namespace-0.5.2.tar.gz", hash = "sha256:566cc33091b5631793ab411f095d46c66391db0a62343cd6b4470265bb04d577"},
+]
+
+[package.dependencies]
+lance-namespace-urllib3-client = "0.5.2"
+
+[[package]]
+name = "lance-namespace-urllib3-client"
+version = "0.5.2"
+description = "Lance Namespace Specification"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "lance_namespace_urllib3_client-0.5.2-py3-none-any.whl", hash = "sha256:83cefb6fd6e5df0b99b5e866ee3d46300d375b75e8af32c27bc16fbf7c1a5978"},
+    {file = "lance_namespace_urllib3_client-0.5.2.tar.gz", hash = "sha256:8a3a238006e6eabc01fc9d385ac3de22ba933aef0ae8987558f3c3199c9b3799"},
+]
+
+[package.dependencies]
+pydantic = ">=2"
+python-dateutil = ">=2.8.2"
+typing-extensions = ">=4.7.1"
+urllib3 = ">=1.25.3,<3.0.0"
+
+[[package]]
+name = "lancedb"
+version = "0.25.3"
+description = "lancedb"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "lancedb-0.25.3-cp39-abi3-macosx_10_15_x86_64.whl", hash = "sha256:1cfa4dd97b33ca8f73288aa4b1baaddc9545ce0d3c8e5d06fba8feb77f42363f"},
+    {file = "lancedb-0.25.3-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:8a7bfe0cb2146f6e78e9f376673ed2f906b93dab84df97dad2ba9fa52f97e152"},
+    {file = "lancedb-0.25.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25a395d07d31da1e13e2631fd9911b15e6d4fb903d34358cea0bd450006364e3"},
+    {file = "lancedb-0.25.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:500beac161f73e3e6826a711efb1d24397d892d07dfdce2c9fb1da73f8de506c"},
+    {file = "lancedb-0.25.3-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2d0fce4187582e48b69430d204665e164002f1b49b03e67747ca8ec2c3083481"},
+    {file = "lancedb-0.25.3-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3035665fb8e4aaff8dff2602747cc77aeba6bc39f1a95345abc3275c97a044cb"},
+    {file = "lancedb-0.25.3-cp39-abi3-win_amd64.whl", hash = "sha256:8c153d976bec79358d328e4c8a287a7b9c918b35b3912fff6864ced6b2a15943"},
+]
+
+[package.dependencies]
+deprecation = "*"
+lance-namespace = ">=0.0.16"
+numpy = "*"
+overrides = {version = ">=0.7", markers = "python_full_version < \"3.12.0\""}
+packaging = "*"
+pyarrow = ">=16"
+pydantic = ">=1.10"
+tqdm = ">=4.27.0"
+
+[package.extras]
+azure = ["adlfs (>=2024.2.0)"]
+clip = ["open-clip-torch", "pillow", "torch"]
+dev = ["pre-commit", "pyright", "ruff", "typing-extensions (>=4.0.0) ; python_full_version < \"3.11.0\""]
+docs = ["mkdocs", "mkdocs-jupyter", "mkdocs-material", "mkdocstrings-python"]
+embeddings = ["awscli (>=1.29.57)", "boto3 (>=1.28.57)", "botocore (>=1.31.57)", "cohere", "colpali-engine (>=0.3.10)", "google-generativeai", "huggingface-hub", "ibm-watsonx-ai (>=1.1.2) ; python_full_version >= \"3.10.0\"", "instructorembedding", "ollama (>=0.3.0)", "open-clip-torch", "openai (>=1.6.1)", "pillow", "requests (>=2.31.0)", "sentence-transformers", "sentencepiece", "torch"]
+pylance = ["pylance (>=0.25)"]
+siglip = ["pillow", "sentencepiece", "torch", "transformers (>=4.41.0)"]
+tests = ["aiohttp", "boto3", "datafusion", "duckdb", "pandas (>=1.4)", "polars (>=0.19,<=1.3.0)", "pyarrow-stubs", "pylance (>=0.25)", "pytest", "pytest-asyncio", "pytest-mock", "pytz", "requests", "tantivy"]
+
+[[package]]
 name = "librt"
 version = "0.8.1"
 description = "Mypyc runtime library"
@@ -1679,6 +1764,88 @@ files = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.4.2"
+description = "Fundamental package for array computing in Python"
+optional = false
+python-versions = ">=3.11"
+groups = ["main"]
+files = [
+    {file = "numpy-2.4.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e7e88598032542bd49af7c4747541422884219056c268823ef6e5e89851c8825"},
+    {file = "numpy-2.4.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7edc794af8b36ca37ef5fcb5e0d128c7e0595c7b96a2318d1badb6fcd8ee86b1"},
+    {file = "numpy-2.4.2-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:6e9f61981ace1360e42737e2bae58b27bf28a1b27e781721047d84bd754d32e7"},
+    {file = "numpy-2.4.2-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:cb7bbb88aa74908950d979eeaa24dbdf1a865e3c7e45ff0121d8f70387b55f73"},
+    {file = "numpy-2.4.2-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4f069069931240b3fc703f1e23df63443dbd6390614c8c44a87d96cd0ec81eb1"},
+    {file = "numpy-2.4.2-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c02ef4401a506fb60b411467ad501e1429a3487abca4664871d9ae0b46c8ba32"},
+    {file = "numpy-2.4.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2653de5c24910e49c2b106499803124dde62a5a1fe0eedeaecf4309a5f639390"},
+    {file = "numpy-2.4.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1ae241bbfc6ae276f94a170b14785e561cb5e7f626b6688cf076af4110887413"},
+    {file = "numpy-2.4.2-cp311-cp311-win32.whl", hash = "sha256:df1b10187212b198dd45fa943d8985a3c8cf854aed4923796e0e019e113a1bda"},
+    {file = "numpy-2.4.2-cp311-cp311-win_amd64.whl", hash = "sha256:b9c618d56a29c9cb1c4da979e9899be7578d2e0b3c24d52079c166324c9e8695"},
+    {file = "numpy-2.4.2-cp311-cp311-win_arm64.whl", hash = "sha256:47c5a6ed21d9452b10227e5e8a0e1c22979811cad7dcc19d8e3e2fb8fa03f1a3"},
+    {file = "numpy-2.4.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:21982668592194c609de53ba4933a7471880ccbaadcc52352694a59ecc860b3a"},
+    {file = "numpy-2.4.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40397bda92382fcec844066efb11f13e1c9a3e2a8e8f318fb72ed8b6db9f60f1"},
+    {file = "numpy-2.4.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:b3a24467af63c67829bfaa61eecf18d5432d4f11992688537be59ecd6ad32f5e"},
+    {file = "numpy-2.4.2-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:805cc8de9fd6e7a22da5aed858e0ab16be5a4db6c873dde1d7451c541553aa27"},
+    {file = "numpy-2.4.2-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d82351358ffbcdcd7b686b90742a9b86632d6c1c051016484fa0b326a0a1548"},
+    {file = "numpy-2.4.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9e35d3e0144137d9fdae62912e869136164534d64a169f86438bc9561b6ad49f"},
+    {file = "numpy-2.4.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:adb6ed2ad29b9e15321d167d152ee909ec73395901b70936f029c3bc6d7f4460"},
+    {file = "numpy-2.4.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8906e71fd8afcb76580404e2a950caef2685df3d2a57fe82a86ac8d33cc007ba"},
+    {file = "numpy-2.4.2-cp312-cp312-win32.whl", hash = "sha256:ec055f6dae239a6299cace477b479cca2fc125c5675482daf1dd886933a1076f"},
+    {file = "numpy-2.4.2-cp312-cp312-win_amd64.whl", hash = "sha256:209fae046e62d0ce6435fcfe3b1a10537e858249b3d9b05829e2a05218296a85"},
+    {file = "numpy-2.4.2-cp312-cp312-win_arm64.whl", hash = "sha256:fbde1b0c6e81d56f5dccd95dd4a711d9b95df1ae4009a60887e56b27e8d903fa"},
+    {file = "numpy-2.4.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:25f2059807faea4b077a2b6837391b5d830864b3543627f381821c646f31a63c"},
+    {file = "numpy-2.4.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bd3a7a9f5847d2fb8c2c6d1c862fa109c31a9abeca1a3c2bd5a64572955b2979"},
+    {file = "numpy-2.4.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:8e4549f8a3c6d13d55041925e912bfd834285ef1dd64d6bc7d542583355e2e98"},
+    {file = "numpy-2.4.2-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:aea4f66ff44dfddf8c2cffd66ba6538c5ec67d389285292fe428cb2c738c8aef"},
+    {file = "numpy-2.4.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c3cd545784805de05aafe1dde61752ea49a359ccba9760c1e5d1c88a93bbf2b7"},
+    {file = "numpy-2.4.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d0d9b7c93578baafcbc5f0b83eaf17b79d345c6f36917ba0c67f45226911d499"},
+    {file = "numpy-2.4.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f74f0f7779cc7ae07d1810aab8ac6b1464c3eafb9e283a40da7309d5e6e48fbb"},
+    {file = "numpy-2.4.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c7ac672d699bf36275c035e16b65539931347d68b70667d28984c9fb34e07fa7"},
+    {file = "numpy-2.4.2-cp313-cp313-win32.whl", hash = "sha256:8e9afaeb0beff068b4d9cd20d322ba0ee1cecfb0b08db145e4ab4dd44a6b5110"},
+    {file = "numpy-2.4.2-cp313-cp313-win_amd64.whl", hash = "sha256:7df2de1e4fba69a51c06c28f5a3de36731eb9639feb8e1cf7e4a7b0daf4cf622"},
+    {file = "numpy-2.4.2-cp313-cp313-win_arm64.whl", hash = "sha256:0fece1d1f0a89c16b03442eae5c56dc0be0c7883b5d388e0c03f53019a4bfd71"},
+    {file = "numpy-2.4.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5633c0da313330fd20c484c78cdd3f9b175b55e1a766c4a174230c6b70ad8262"},
+    {file = "numpy-2.4.2-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:d9f64d786b3b1dd742c946c42d15b07497ed14af1a1f3ce840cce27daa0ce913"},
+    {file = "numpy-2.4.2-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:b21041e8cb6a1eb5312dd1d2f80a94d91efffb7a06b70597d44f1bd2dfc315ab"},
+    {file = "numpy-2.4.2-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:00ab83c56211a1d7c07c25e3217ea6695e50a3e2f255053686b081dc0b091a82"},
+    {file = "numpy-2.4.2-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fb882da679409066b4603579619341c6d6898fc83a8995199d5249f986e8e8f"},
+    {file = "numpy-2.4.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:66cb9422236317f9d44b67b4d18f44efe6e9c7f8794ac0462978513359461554"},
+    {file = "numpy-2.4.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0f01dcf33e73d80bd8dc0f20a71303abbafa26a19e23f6b68d1aa9990af90257"},
+    {file = "numpy-2.4.2-cp313-cp313t-win32.whl", hash = "sha256:52b913ec40ff7ae845687b0b34d8d93b60cb66dcee06996dd5c99f2fc9328657"},
+    {file = "numpy-2.4.2-cp313-cp313t-win_amd64.whl", hash = "sha256:5eea80d908b2c1f91486eb95b3fb6fab187e569ec9752ab7d9333d2e66bf2d6b"},
+    {file = "numpy-2.4.2-cp313-cp313t-win_arm64.whl", hash = "sha256:fd49860271d52127d61197bb50b64f58454e9f578cb4b2c001a6de8b1f50b0b1"},
+    {file = "numpy-2.4.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:444be170853f1f9d528428eceb55f12918e4fda5d8805480f36a002f1415e09b"},
+    {file = "numpy-2.4.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d1240d50adff70c2a88217698ca844723068533f3f5c5fa6ee2e3220e3bdb000"},
+    {file = "numpy-2.4.2-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:7cdde6de52fb6664b00b056341265441192d1291c130e99183ec0d4b110ff8b1"},
+    {file = "numpy-2.4.2-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:cda077c2e5b780200b6b3e09d0b42205a3d1c68f30c6dceb90401c13bff8fe74"},
+    {file = "numpy-2.4.2-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d30291931c915b2ab5717c2974bb95ee891a1cf22ebc16a8006bd59cd210d40a"},
+    {file = "numpy-2.4.2-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bba37bc29d4d85761deed3954a1bc62be7cf462b9510b51d367b769a8c8df325"},
+    {file = "numpy-2.4.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b2f0073ed0868db1dcd86e052d37279eef185b9c8db5bf61f30f46adac63c909"},
+    {file = "numpy-2.4.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7f54844851cdb630ceb623dcec4db3240d1ac13d4990532446761baede94996a"},
+    {file = "numpy-2.4.2-cp314-cp314-win32.whl", hash = "sha256:12e26134a0331d8dbd9351620f037ec470b7c75929cb8a1537f6bfe411152a1a"},
+    {file = "numpy-2.4.2-cp314-cp314-win_amd64.whl", hash = "sha256:068cdb2d0d644cdb45670810894f6a0600797a69c05f1ac478e8d31670b8ee75"},
+    {file = "numpy-2.4.2-cp314-cp314-win_arm64.whl", hash = "sha256:6ed0be1ee58eef41231a5c943d7d1375f093142702d5723ca2eb07db9b934b05"},
+    {file = "numpy-2.4.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:98f16a80e917003a12c0580f97b5f875853ebc33e2eaa4bccfc8201ac6869308"},
+    {file = "numpy-2.4.2-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:20abd069b9cda45874498b245c8015b18ace6de8546bf50dfa8cea1696ed06ef"},
+    {file = "numpy-2.4.2-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:e98c97502435b53741540a5717a6749ac2ada901056c7db951d33e11c885cc7d"},
+    {file = "numpy-2.4.2-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:da6cad4e82cb893db4b69105c604d805e0c3ce11501a55b5e9f9083b47d2ffe8"},
+    {file = "numpy-2.4.2-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9e4424677ce4b47fe73c8b5556d876571f7c6945d264201180db2dc34f676ab5"},
+    {file = "numpy-2.4.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2b8f157c8a6f20eb657e240f8985cc135598b2b46985c5bccbde7616dc9c6b1e"},
+    {file = "numpy-2.4.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5daf6f3914a733336dab21a05cdec343144600e964d2fcdabaac0c0269874b2a"},
+    {file = "numpy-2.4.2-cp314-cp314t-win32.whl", hash = "sha256:8c50dd1fc8826f5b26a5ee4d77ca55d88a895f4e4819c7ecc2a9f5905047a443"},
+    {file = "numpy-2.4.2-cp314-cp314t-win_amd64.whl", hash = "sha256:fcf92bee92742edd401ba41135185866f7026c502617f422eb432cfeca4fe236"},
+    {file = "numpy-2.4.2-cp314-cp314t-win_arm64.whl", hash = "sha256:1f92f53998a17265194018d1cc321b2e96e900ca52d54c7c77837b71b9465181"},
+    {file = "numpy-2.4.2-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:89f7268c009bc492f506abd6f5265defa7cb3f7487dc21d357c3d290add45082"},
+    {file = "numpy-2.4.2-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:e6dee3bb76aa4009d5a912180bf5b2de012532998d094acee25d9cb8dee3e44a"},
+    {file = "numpy-2.4.2-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:cd2bd2bbed13e213d6b55dc1d035a4f91748a7d3edc9480c13898b0353708920"},
+    {file = "numpy-2.4.2-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:cf28c0c1d4c4bf00f509fa7eb02c58d7caf221b50b467bcb0d9bbf1584d5c821"},
+    {file = "numpy-2.4.2-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e04ae107ac591763a47398bb45b568fc38f02dbc4aa44c063f67a131f99346cb"},
+    {file = "numpy-2.4.2-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:602f65afdef699cda27ec0b9224ae5dc43e328f4c24c689deaf77133dbee74d0"},
+    {file = "numpy-2.4.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:be71bf1edb48ebbbf7f6337b5bfd2f895d1902f6335a5830b20141fc126ffba0"},
+    {file = "numpy-2.4.2.tar.gz", hash = "sha256:659a6107e31a83c4e33f763942275fd278b21d095094044eb35569e86a21ddae"},
+]
+
+[[package]]
 name = "ollama"
 version = "0.6.1"
 description = "The official Python client for Ollama."
@@ -1723,6 +1890,19 @@ realtime = ["websockets (>=13,<16)"]
 voice-helpers = ["numpy (>=2.0.2)", "sounddevice (>=0.5.1)"]
 
 [[package]]
+name = "overrides"
+version = "7.7.0"
+description = "A decorator to automatically detect mismatch when overriding a method."
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+markers = "python_version == \"3.11\""
+files = [
+    {file = "overrides-7.7.0-py3-none-any.whl", hash = "sha256:c7ed9d062f78b8e4c1a7b70bd8796b35ead4d9f510227ef9c5dc7626c60d7e49"},
+    {file = "overrides-7.7.0.tar.gz", hash = "sha256:55158fa3d93b98cc75299b1e67078ad9003ca27945c76162c1c0766d6f91820a"},
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 description = "Core utilities for Python packages"
@@ -1733,6 +1913,98 @@ files = [
     {file = "packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529"},
     {file = "packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4"},
 ]
+
+[[package]]
+name = "pandas"
+version = "3.0.1"
+description = "Powerful data structures for data analysis, time series, and statistics"
+optional = false
+python-versions = ">=3.11"
+groups = ["main"]
+files = [
+    {file = "pandas-3.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:de09668c1bf3b925c07e5762291602f0d789eca1b3a781f99c1c78f6cac0e7ea"},
+    {file = "pandas-3.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:24ba315ba3d6e5806063ac6eb717504e499ce30bd8c236d8693a5fd3f084c796"},
+    {file = "pandas-3.0.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:406ce835c55bac912f2a0dcfaf27c06d73c6b04a5dde45f1fd3169ce31337389"},
+    {file = "pandas-3.0.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:830994d7e1f31dd7e790045235605ab61cff6c94defc774547e8b7fdfbff3dc7"},
+    {file = "pandas-3.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a64ce8b0f2de1d2efd2ae40b0abe7f8ae6b29fbfb3812098ed5a6f8e235ad9bf"},
+    {file = "pandas-3.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9832c2c69da24b602c32e0c7b1b508a03949c18ba08d4d9f1c1033426685b447"},
+    {file = "pandas-3.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:84f0904a69e7365f79a0c77d3cdfccbfb05bf87847e3a51a41e1426b0edb9c79"},
+    {file = "pandas-3.0.1-cp311-cp311-win_arm64.whl", hash = "sha256:4a68773d5a778afb31d12e34f7dd4612ab90de8c6fb1d8ffe5d4a03b955082a1"},
+    {file = "pandas-3.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:476f84f8c20c9f5bc47252b66b4bb25e1a9fc2fa98cead96744d8116cb85771d"},
+    {file = "pandas-3.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0ab749dfba921edf641d4036c4c21c0b3ea70fea478165cb98a998fb2a261955"},
+    {file = "pandas-3.0.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b8e36891080b87823aff3640c78649b91b8ff6eea3c0d70aeabd72ea43ab069b"},
+    {file = "pandas-3.0.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:532527a701281b9dd371e2f582ed9094f4c12dd9ffb82c0c54ee28d8ac9520c4"},
+    {file = "pandas-3.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:356e5c055ed9b0da1580d465657bc7d00635af4fd47f30afb23025352ba764d1"},
+    {file = "pandas-3.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9d810036895f9ad6345b8f2a338dd6998a74e8483847403582cab67745bff821"},
+    {file = "pandas-3.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:536232a5fe26dd989bd633e7a0c450705fdc86a207fec7254a55e9a22950fe43"},
+    {file = "pandas-3.0.1-cp312-cp312-win_arm64.whl", hash = "sha256:0f463ebfd8de7f326d38037c7363c6dacb857c5881ab8961fb387804d6daf2f7"},
+    {file = "pandas-3.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5272627187b5d9c20e55d27caf5f2cd23e286aba25cadf73c8590e432e2b7262"},
+    {file = "pandas-3.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:661e0f665932af88c7877f31da0dc743fe9c8f2524bdffe23d24fdcb67ef9d56"},
+    {file = "pandas-3.0.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:75e6e292ff898679e47a2199172593d9f6107fd2dd3617c22c2946e97d5df46e"},
+    {file = "pandas-3.0.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1ff8cf1d2896e34343197685f432450ec99a85ba8d90cce2030c5eee2ef98791"},
+    {file = "pandas-3.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:eca8b4510f6763f3d37359c2105df03a7a221a508f30e396a51d0713d462e68a"},
+    {file = "pandas-3.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:06aff2ad6f0b94a17822cf8b83bbb563b090ed82ff4fe7712db2ce57cd50d9b8"},
+    {file = "pandas-3.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:9fea306c783e28884c29057a1d9baa11a349bbf99538ec1da44c8476563d1b25"},
+    {file = "pandas-3.0.1-cp313-cp313-win_arm64.whl", hash = "sha256:a8d37a43c52917427e897cb2e429f67a449327394396a81034a4449b99afda59"},
+    {file = "pandas-3.0.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:d54855f04f8246ed7b6fc96b05d4871591143c46c0b6f4af874764ed0d2d6f06"},
+    {file = "pandas-3.0.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4e1b677accee34a09e0dc2ce5624e4a58a1870ffe56fc021e9caf7f23cd7668f"},
+    {file = "pandas-3.0.1-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a9cabbdcd03f1b6cd254d6dda8ae09b0252524be1592594c00b7895916cb1324"},
+    {file = "pandas-3.0.1-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5ae2ab1f166668b41e770650101e7090824fd34d17915dd9cd479f5c5e0065e9"},
+    {file = "pandas-3.0.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6bf0603c2e30e2cafac32807b06435f28741135cb8697eae8b28c7d492fc7d76"},
+    {file = "pandas-3.0.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6c426422973973cae1f4a23e51d4ae85974f44871b24844e4f7de752dd877098"},
+    {file = "pandas-3.0.1-cp313-cp313t-win_amd64.whl", hash = "sha256:b03f91ae8c10a85c1613102c7bef5229b5379f343030a3ccefeca8a33414cf35"},
+    {file = "pandas-3.0.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:99d0f92ed92d3083d140bf6b97774f9f13863924cf3f52a70711f4e7588f9d0a"},
+    {file = "pandas-3.0.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3b66857e983208654294bb6477b8a63dee26b37bdd0eb34d010556e91261784f"},
+    {file = "pandas-3.0.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:56cf59638bf24dc9bdf2154c81e248b3289f9a09a6d04e63608c159022352749"},
+    {file = "pandas-3.0.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1a9f55e0f46951874b863d1f3906dcb57df2d9be5c5847ba4dfb55b2c815249"},
+    {file = "pandas-3.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1849f0bba9c8a2fb0f691d492b834cc8dadf617e29015c66e989448d58d011ee"},
+    {file = "pandas-3.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c3d288439e11b5325b02ae6e9cc83e6805a62c40c5a6220bea9beb899c073b1c"},
+    {file = "pandas-3.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:93325b0fe372d192965f4cca88d97667f49557398bbf94abdda3bf1b591dbe66"},
+    {file = "pandas-3.0.1-cp314-cp314-win_arm64.whl", hash = "sha256:97ca08674e3287c7148f4858b01136f8bdfe7202ad25ad04fec602dd1d29d132"},
+    {file = "pandas-3.0.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:58eeb1b2e0fb322befcf2bbc9ba0af41e616abadb3d3414a6bc7167f6cbfce32"},
+    {file = "pandas-3.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cd9af1276b5ca9e298bd79a26bda32fa9cc87ed095b2a9a60978d2ca058eaf87"},
+    {file = "pandas-3.0.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94f87a04984d6b63788327cd9f79dda62b7f9043909d2440ceccf709249ca988"},
+    {file = "pandas-3.0.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:85fe4c4df62e1e20f9db6ebfb88c844b092c22cd5324bdcf94bfa2fc1b391221"},
+    {file = "pandas-3.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:331ca75a2f8672c365ae25c0b29e46f5ac0c6551fdace8eec4cd65e4fac271ff"},
+    {file = "pandas-3.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:15860b1fdb1973fffade772fdb931ccf9b2f400a3f5665aef94a00445d7d8dd5"},
+    {file = "pandas-3.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:44f1364411d5670efa692b146c748f4ed013df91ee91e9bec5677fb1fd58b937"},
+    {file = "pandas-3.0.1-cp314-cp314t-win_arm64.whl", hash = "sha256:108dd1790337a494aa80e38def654ca3f0968cf4f362c85f44c15e471667102d"},
+    {file = "pandas-3.0.1.tar.gz", hash = "sha256:4186a699674af418f655dbd420ed87f50d56b4cd6603784279d9eef6627823c8"},
+]
+
+[package.dependencies]
+numpy = [
+    {version = ">=1.26.0", markers = "python_version < \"3.14\""},
+    {version = ">=2.3.3", markers = "python_version >= \"3.14\""},
+]
+python-dateutil = ">=2.8.2"
+tzdata = {version = "*", markers = "sys_platform == \"win32\" or sys_platform == \"emscripten\""}
+
+[package.extras]
+all = ["PyQt5 (>=5.15.9)", "SQLAlchemy (>=2.0.36)", "adbc-driver-postgresql (>=1.2.0)", "adbc-driver-sqlite (>=1.2.0)", "beautifulsoup4 (>=4.12.3)", "bottleneck (>=1.4.2)", "fastparquet (>=2024.11.0)", "fsspec (>=2024.10.0)", "gcsfs (>=2024.10.0)", "html5lib (>=1.1)", "hypothesis (>=6.116.0)", "jinja2 (>=3.1.5)", "lxml (>=5.3.0)", "matplotlib (>=3.9.3)", "numba (>=0.60.0)", "numexpr (>=2.10.2)", "odfpy (>=1.4.1)", "openpyxl (>=3.1.5)", "psycopg2 (>=2.9.10)", "pyarrow (>=13.0.0)", "pyiceberg (>=0.8.1)", "pymysql (>=1.1.1)", "pyreadstat (>=1.2.8)", "pytest (>=8.3.4)", "pytest-xdist (>=3.6.1)", "python-calamine (>=0.3.0)", "pytz (>=2024.2)", "pyxlsb (>=1.0.10)", "qtpy (>=2.4.2)", "s3fs (>=2024.10.0)", "scipy (>=1.14.1)", "tables (>=3.10.1)", "tabulate (>=0.9.0)", "xarray (>=2024.10.0)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.2.0)", "zstandard (>=0.23.0)"]
+aws = ["s3fs (>=2024.10.0)"]
+clipboard = ["PyQt5 (>=5.15.9)", "qtpy (>=2.4.2)"]
+compression = ["zstandard (>=0.23.0)"]
+computation = ["scipy (>=1.14.1)", "xarray (>=2024.10.0)"]
+excel = ["odfpy (>=1.4.1)", "openpyxl (>=3.1.5)", "python-calamine (>=0.3.0)", "pyxlsb (>=1.0.10)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.2.0)"]
+feather = ["pyarrow (>=13.0.0)"]
+fss = ["fsspec (>=2024.10.0)"]
+gcp = ["gcsfs (>=2024.10.0)"]
+hdf5 = ["tables (>=3.10.1)"]
+html = ["beautifulsoup4 (>=4.12.3)", "html5lib (>=1.1)", "lxml (>=5.3.0)"]
+iceberg = ["pyiceberg (>=0.8.1)"]
+mysql = ["SQLAlchemy (>=2.0.36)", "pymysql (>=1.1.1)"]
+output-formatting = ["jinja2 (>=3.1.5)", "tabulate (>=0.9.0)"]
+parquet = ["pyarrow (>=13.0.0)"]
+performance = ["bottleneck (>=1.4.2)", "numba (>=0.60.0)", "numexpr (>=2.10.2)"]
+plot = ["matplotlib (>=3.9.3)"]
+postgresql = ["SQLAlchemy (>=2.0.36)", "adbc-driver-postgresql (>=1.2.0)", "psycopg2 (>=2.9.10)"]
+pyarrow = ["pyarrow (>=13.0.0)"]
+spss = ["pyreadstat (>=1.2.8)"]
+sql-other = ["SQLAlchemy (>=2.0.36)", "adbc-driver-postgresql (>=1.2.0)", "adbc-driver-sqlite (>=1.2.0)"]
+test = ["hypothesis (>=6.116.0)", "pytest (>=8.3.4)", "pytest-xdist (>=3.6.1)"]
+timezone = ["pytz (>=2024.2)"]
+xml = ["lxml (>=5.3.0)"]
 
 [[package]]
 name = "pathspec"
@@ -1961,6 +2233,66 @@ files = [
 [package.extras]
 dev = ["abi3audit", "black", "check-manifest", "colorama ; os_name == \"nt\"", "coverage", "packaging", "psleak", "pylint", "pyperf", "pypinfo", "pyreadline3 ; os_name == \"nt\"", "pytest", "pytest-cov", "pytest-instafail", "pytest-xdist", "pywin32 ; os_name == \"nt\" and implementation_name != \"pypy\"", "requests", "rstcheck", "ruff", "setuptools", "sphinx", "sphinx_rtd_theme", "toml-sort", "twine", "validate-pyproject[all]", "virtualenv", "vulture", "wheel", "wheel ; os_name == \"nt\" and implementation_name != \"pypy\"", "wmi ; os_name == \"nt\" and implementation_name != \"pypy\""]
 test = ["psleak", "pytest", "pytest-instafail", "pytest-xdist", "pywin32 ; os_name == \"nt\" and implementation_name != \"pypy\"", "setuptools", "wheel ; os_name == \"nt\" and implementation_name != \"pypy\"", "wmi ; os_name == \"nt\" and implementation_name != \"pypy\""]
+
+[[package]]
+name = "pyarrow"
+version = "23.0.1"
+description = "Python library for Apache Arrow"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "pyarrow-23.0.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:3fab8f82571844eb3c460f90a75583801d14ca0cc32b1acc8c361650e006fd56"},
+    {file = "pyarrow-23.0.1-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:3f91c038b95f71ddfc865f11d5876c42f343b4495535bd262c7b321b0b94507c"},
+    {file = "pyarrow-23.0.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:d0744403adabef53c985a7f8a082b502a368510c40d184df349a0a8754533258"},
+    {file = "pyarrow-23.0.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:c33b5bf406284fd0bba436ed6f6c3ebe8e311722b441d89397c54f871c6863a2"},
+    {file = "pyarrow-23.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ddf743e82f69dcd6dbbcb63628895d7161e04e56794ef80550ac6f3315eeb1d5"},
+    {file = "pyarrow-23.0.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e052a211c5ac9848ae15d5ec875ed0943c0221e2fcfe69eee80b604b4e703222"},
+    {file = "pyarrow-23.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:5abde149bb3ce524782d838eb67ac095cd3fd6090eba051130589793f1a7f76d"},
+    {file = "pyarrow-23.0.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:6f0147ee9e0386f519c952cc670eb4a8b05caa594eeffe01af0e25f699e4e9bb"},
+    {file = "pyarrow-23.0.1-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:0ae6e17c828455b6265d590100c295193f93cc5675eb0af59e49dbd00d2de350"},
+    {file = "pyarrow-23.0.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:fed7020203e9ef273360b9e45be52a2a47d3103caf156a30ace5247ffb51bdbd"},
+    {file = "pyarrow-23.0.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:26d50dee49d741ac0e82185033488d28d35be4d763ae6f321f97d1140eb7a0e9"},
+    {file = "pyarrow-23.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3c30143b17161310f151f4a2bcfe41b5ff744238c1039338779424e38579d701"},
+    {file = "pyarrow-23.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:db2190fa79c80a23fdd29fef4b8992893f024ae7c17d2f5f4db7171fa30c2c78"},
+    {file = "pyarrow-23.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:f00f993a8179e0e1c9713bcc0baf6d6c01326a406a9c23495ec1ba9c9ebf2919"},
+    {file = "pyarrow-23.0.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:f4b0dbfa124c0bb161f8b5ebb40f1a680b70279aa0c9901d44a2b5a20806039f"},
+    {file = "pyarrow-23.0.1-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:7707d2b6673f7de054e2e83d59f9e805939038eebe1763fe811ee8fa5c0cd1a7"},
+    {file = "pyarrow-23.0.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:86ff03fb9f1a320266e0de855dee4b17da6794c595d207f89bba40d16b5c78b9"},
+    {file = "pyarrow-23.0.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:813d99f31275919c383aab17f0f455a04f5a429c261cc411b1e9a8f5e4aaaa05"},
+    {file = "pyarrow-23.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bf5842f960cddd2ef757d486041d57c96483efc295a8c4a0e20e704cbbf39c67"},
+    {file = "pyarrow-23.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:564baf97c858ecc03ec01a41062e8f4698abc3e6e2acd79c01c2e97880a19730"},
+    {file = "pyarrow-23.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:07deae7783782ac7250989a7b2ecde9b3c343a643f82e8a4df03d93b633006f0"},
+    {file = "pyarrow-23.0.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6b8fda694640b00e8af3c824f99f789e836720aa8c9379fb435d4c4953a756b8"},
+    {file = "pyarrow-23.0.1-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:8ff51b1addc469b9444b7c6f3548e19dc931b172ab234e995a60aea9f6e6025f"},
+    {file = "pyarrow-23.0.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:71c5be5cbf1e1cb6169d2a0980850bccb558ddc9b747b6206435313c47c37677"},
+    {file = "pyarrow-23.0.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9b6f4f17b43bc39d56fec96e53fe89d94bac3eb134137964371b45352d40d0c2"},
+    {file = "pyarrow-23.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9fc13fc6c403d1337acab46a2c4346ca6c9dec5780c3c697cf8abfd5e19b6b37"},
+    {file = "pyarrow-23.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c16ed4f53247fa3ffb12a14d236de4213a4415d127fe9cebed33d51671113e2"},
+    {file = "pyarrow-23.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:cecfb12ef629cf6be0b1887f9f86463b0dd3dc3195ae6224e74006be4736035a"},
+    {file = "pyarrow-23.0.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:29f7f7419a0e30264ea261fdc0e5fe63ce5a6095003db2945d7cd78df391a7e1"},
+    {file = "pyarrow-23.0.1-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:33d648dc25b51fd8055c19e4261e813dfc4d2427f068bcecc8b53d01b81b0500"},
+    {file = "pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd395abf8f91c673dd3589cadc8cc1ee4e8674fa61b2e923c8dd215d9c7d1f41"},
+    {file = "pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:00be9576d970c31defb5c32eb72ef585bf600ef6d0a82d5eccaae96639cf9d07"},
+    {file = "pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c2139549494445609f35a5cda4eb94e2c9e4d704ce60a095b342f82460c73a83"},
+    {file = "pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7044b442f184d84e2351e5084600f0d7343d6117aabcbc1ac78eb1ae11eb4125"},
+    {file = "pyarrow-23.0.1-cp313-cp313t-win_amd64.whl", hash = "sha256:a35581e856a2fafa12f3f54fce4331862b1cfb0bef5758347a858a4aa9d6bae8"},
+    {file = "pyarrow-23.0.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:5df1161da23636a70838099d4aaa65142777185cc0cdba4037a18cee7d8db9ca"},
+    {file = "pyarrow-23.0.1-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:fa8e51cb04b9f8c9c5ace6bab63af9a1f88d35c0d6cbf53e8c17c098552285e1"},
+    {file = "pyarrow-23.0.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:0b95a3994f015be13c63148fef8832e8a23938128c185ee951c98908a696e0eb"},
+    {file = "pyarrow-23.0.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4982d71350b1a6e5cfe1af742c53dfb759b11ce14141870d05d9e540d13bc5d1"},
+    {file = "pyarrow-23.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c250248f1fe266db627921c89b47b7c06fee0489ad95b04d50353537d74d6886"},
+    {file = "pyarrow-23.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f4763b83c11c16e5f4c15601ba6dfa849e20723b46aa2617cb4bffe8768479f"},
+    {file = "pyarrow-23.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:3a4c85ef66c134161987c17b147d6bffdca4566f9a4c1d81a0a01cdf08414ea5"},
+    {file = "pyarrow-23.0.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:17cd28e906c18af486a499422740298c52d7c6795344ea5002a7720b4eadf16d"},
+    {file = "pyarrow-23.0.1-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:76e823d0e86b4fb5e1cf4a58d293036e678b5a4b03539be933d3b31f9406859f"},
+    {file = "pyarrow-23.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a62e1899e3078bf65943078b3ad2a6ddcacf2373bc06379aac61b1e548a75814"},
+    {file = "pyarrow-23.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:df088e8f640c9fae3b1f495b3c64755c4e719091caf250f3a74d095ddf3c836d"},
+    {file = "pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:46718a220d64677c93bc243af1d44b55998255427588e400677d7192671845c7"},
+    {file = "pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a09f3876e87f48bc2f13583ab551f0379e5dfb83210391e68ace404181a20690"},
+    {file = "pyarrow-23.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:527e8d899f14bd15b740cd5a54ad56b7f98044955373a17179d5956ddb93d9ce"},
+    {file = "pyarrow-23.0.1.tar.gz", hash = "sha256:b8c5873e33440b2bc2f4a79d2b47017a89c5a24116c055625e6f2ee50523f019"},
+]
 
 [[package]]
 name = "pydantic"
@@ -2202,6 +2534,21 @@ typing-extensions = {version = ">=4.12", markers = "python_version < \"3.13\""}
 [package.extras]
 docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1)"]
 testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+description = "Extensions to the standard Python datetime module"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+groups = ["main"]
+files = [
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
+]
+
+[package.dependencies]
+six = ">=1.5"
 
 [[package]]
 name = "python-dotenv"
@@ -2649,6 +2996,18 @@ files = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+groups = ["main"]
+files = [
+    {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
+    {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 description = "Sniff out which async library your code is running under"
@@ -2827,6 +3186,143 @@ slack = ["slack-sdk"]
 telegram = ["requests"]
 
 [[package]]
+name = "tree-sitter"
+version = "0.25.2"
+description = "Python bindings to the Tree-sitter parsing library"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "tree-sitter-0.25.2.tar.gz", hash = "sha256:fe43c158555da46723b28b52e058ad444195afd1db3ca7720c59a254544e9c20"},
+    {file = "tree_sitter-0.25.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:72a510931c3c25f134aac2daf4eb4feca99ffe37a35896d7150e50ac3eee06c7"},
+    {file = "tree_sitter-0.25.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:44488e0e78146f87baaa009736886516779253d6d6bac3ef636ede72bc6a8234"},
+    {file = "tree_sitter-0.25.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2f8e7d6b2f8489d4a9885e3adcaef4bc5ff0a275acd990f120e29c4ab3395c5"},
+    {file = "tree_sitter-0.25.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:20b570690f87f1da424cd690e51cc56728d21d63f4abd4b326d382a30353acc7"},
+    {file = "tree_sitter-0.25.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a0ec41b895da717bc218a42a3a7a0bfcfe9a213d7afaa4255353901e0e21f696"},
+    {file = "tree_sitter-0.25.2-cp310-cp310-win_amd64.whl", hash = "sha256:7712335855b2307a21ae86efe949c76be36c6068d76df34faa27ce9ee40ff444"},
+    {file = "tree_sitter-0.25.2-cp310-cp310-win_arm64.whl", hash = "sha256:a925364eb7fbb9cdce55a9868f7525a1905af512a559303bd54ef468fd88cb37"},
+    {file = "tree_sitter-0.25.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b8ca72d841215b6573ed0655b3a5cd1133f9b69a6fa561aecad40dca9029d75b"},
+    {file = "tree_sitter-0.25.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cc0351cfe5022cec5a77645f647f92a936b38850346ed3f6d6babfbeeeca4d26"},
+    {file = "tree_sitter-0.25.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1799609636c0193e16c38f366bda5af15b1ce476df79ddaae7dd274df9e44266"},
+    {file = "tree_sitter-0.25.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3e65ae456ad0d210ee71a89ee112ac7e72e6c2e5aac1b95846ecc7afa68a194c"},
+    {file = "tree_sitter-0.25.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:49ee3c348caa459244ec437ccc7ff3831f35977d143f65311572b8ba0a5f265f"},
+    {file = "tree_sitter-0.25.2-cp311-cp311-win_amd64.whl", hash = "sha256:56ac6602c7d09c2c507c55e58dc7026b8988e0475bd0002f8a386cce5e8e8adc"},
+    {file = "tree_sitter-0.25.2-cp311-cp311-win_arm64.whl", hash = "sha256:b3d11a3a3ac89bb8a2543d75597f905a9926f9c806f40fcca8242922d1cc6ad5"},
+    {file = "tree_sitter-0.25.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ddabfff809ffc983fc9963455ba1cecc90295803e06e140a4c83e94c1fa3d960"},
+    {file = "tree_sitter-0.25.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c0c0ab5f94938a23fe81928a21cc0fac44143133ccc4eb7eeb1b92f84748331c"},
+    {file = "tree_sitter-0.25.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd12d80d91d4114ca097626eb82714618dcdfacd6a5e0955216c6485c350ef99"},
+    {file = "tree_sitter-0.25.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b43a9e4c89d4d0839de27cd4d6902d33396de700e9ff4c5ab7631f277a85ead9"},
+    {file = "tree_sitter-0.25.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbb1706407c0e451c4f8cc016fec27d72d4b211fdd3173320b1ada7a6c74c3ac"},
+    {file = "tree_sitter-0.25.2-cp312-cp312-win_amd64.whl", hash = "sha256:6d0302550bbe4620a5dc7649517c4409d74ef18558276ce758419cf09e578897"},
+    {file = "tree_sitter-0.25.2-cp312-cp312-win_arm64.whl", hash = "sha256:0c8b6682cac77e37cfe5cf7ec388844957f48b7bd8d6321d0ca2d852994e10d5"},
+    {file = "tree_sitter-0.25.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0628671f0de69bb279558ef6b640bcfc97864fe0026d840f872728a86cd6b6cd"},
+    {file = "tree_sitter-0.25.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f5ddcd3e291a749b62521f71fc953f66f5fd9743973fd6dd962b092773569601"},
+    {file = "tree_sitter-0.25.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd88fbb0f6c3a0f28f0a68d72df88e9755cf5215bae146f5a1bdc8362b772053"},
+    {file = "tree_sitter-0.25.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b878e296e63661c8e124177cc3084b041ba3f5936b43076d57c487822426f614"},
+    {file = "tree_sitter-0.25.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d77605e0d353ba3fe5627e5490f0fbfe44141bafa4478d88ef7954a61a848dae"},
+    {file = "tree_sitter-0.25.2-cp313-cp313-win_amd64.whl", hash = "sha256:463c032bd02052d934daa5f45d183e0521ceb783c2548501cf034b0beba92c9b"},
+    {file = "tree_sitter-0.25.2-cp313-cp313-win_arm64.whl", hash = "sha256:b3f63a1796886249bd22c559a5944d64d05d43f2be72961624278eff0dcc5cb8"},
+    {file = "tree_sitter-0.25.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:65d3c931013ea798b502782acab986bbf47ba2c452610ab0776cf4a8ef150fc0"},
+    {file = "tree_sitter-0.25.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bda059af9d621918efb813b22fb06b3fe00c3e94079c6143fcb2c565eb44cb87"},
+    {file = "tree_sitter-0.25.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eac4e8e4c7060c75f395feec46421eb61212cb73998dbe004b7384724f3682ab"},
+    {file = "tree_sitter-0.25.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:260586381b23be33b6191a07cea3d44ecbd6c01aa4c6b027a0439145fcbc3358"},
+    {file = "tree_sitter-0.25.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7d2ee1acbacebe50ba0f85fff1bc05e65d877958f00880f49f9b2af38dce1af0"},
+    {file = "tree_sitter-0.25.2-cp314-cp314-win_amd64.whl", hash = "sha256:4973b718fcadfb04e59e746abfbb0288694159c6aeecd2add59320c03368c721"},
+    {file = "tree_sitter-0.25.2-cp314-cp314-win_arm64.whl", hash = "sha256:b8d4429954a3beb3e844e2872610d2a4800ba4eb42bb1990c6a4b1949b18459f"},
+]
+
+[package.extras]
+docs = ["sphinx (>=8.1,<9.0)", "sphinx-book-theme"]
+tests = ["tree-sitter-html (>=0.23.2)", "tree-sitter-javascript (>=0.23.1)", "tree-sitter-json (>=0.24.8)", "tree-sitter-python (>=0.23.6)", "tree-sitter-rust (>=0.23.2)"]
+
+[[package]]
+name = "tree-sitter-c-sharp"
+version = "0.23.1"
+description = "C# grammar for tree-sitter"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "tree_sitter_c_sharp-0.23.1-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2b612a6e5bd17bb7fa2aab4bb6fc1fba45c94f09cb034ab332e45603b86e32fd"},
+    {file = "tree_sitter_c_sharp-0.23.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a8b98f62bc53efcd4d971151950c9b9cd5cbe3bacdb0cd69fdccac63350d83e"},
+    {file = "tree_sitter_c_sharp-0.23.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:986e93d845a438ec3c4416401aa98e6a6f6631d644bbbc2e43fcb915c51d255d"},
+    {file = "tree_sitter_c_sharp-0.23.1-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8024e466b2f5611c6dc90321f232d8584893c7fb88b75e4a831992f877616d2"},
+    {file = "tree_sitter_c_sharp-0.23.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7f9bf876866835492281d336b9e1f9626ab668737f74e914c31d285261507da7"},
+    {file = "tree_sitter_c_sharp-0.23.1-cp39-abi3-win_amd64.whl", hash = "sha256:ae9a9e859e8f44e2b07578d44f9a220d3fa25b688966708af6aa55d42abeebb3"},
+    {file = "tree_sitter_c_sharp-0.23.1-cp39-abi3-win_arm64.whl", hash = "sha256:c81548347a93347be4f48cb63ec7d60ef4b0efa91313330e69641e49aa5a08c5"},
+    {file = "tree_sitter_c_sharp-0.23.1.tar.gz", hash = "sha256:322e2cfd3a547a840375276b2aea3335fa6458aeac082f6c60fec3f745c967eb"},
+]
+
+[package.extras]
+core = ["tree-sitter (>=0.22,<1.0)"]
+
+[[package]]
+name = "tree-sitter-embedded-template"
+version = "0.25.0"
+description = "Embedded Template (ERB, EJS) grammar for tree-sitter"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "tree_sitter_embedded_template-0.25.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:fa0d06467199aeb33fb3d6fa0665bf9b7d5a32621ffdaf37fd8249f8a8050649"},
+    {file = "tree_sitter_embedded_template-0.25.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:fc7aacbc2985a5d7e7fe7334f44dffe24c38fb0a8295c4188a04cf21a3d64a73"},
+    {file = "tree_sitter_embedded_template-0.25.0-cp310-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a7c88c3dd8b94b3c9efe8ae071ff6b1b936a27ac5f6e651845c3b9631fa4c1c2"},
+    {file = "tree_sitter_embedded_template-0.25.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:025f7ca84218dcd8455efc901bdbcc2689fb694f3a636c0448e322a23d4bc96b"},
+    {file = "tree_sitter_embedded_template-0.25.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b5dc1aef6ffa3fae621fe037d85dd98948b597afba20df29d779c426be813ee5"},
+    {file = "tree_sitter_embedded_template-0.25.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:d0a35cfe634c44981a516243bc039874580e02a2990669313730187ce83a5bc6"},
+    {file = "tree_sitter_embedded_template-0.25.0-cp310-abi3-win_amd64.whl", hash = "sha256:3e05a4ac013d54505e75ae48e1a0e9db9aab19949fe15d9f4c7345b11a84a069"},
+    {file = "tree_sitter_embedded_template-0.25.0-cp310-abi3-win_arm64.whl", hash = "sha256:2751d402179ac0e83f2065b249d8fe6df0718153f1636bcb6a02bde3e5730db9"},
+    {file = "tree_sitter_embedded_template-0.25.0.tar.gz", hash = "sha256:7d72d5e8a1d1d501a7c90e841b51f1449a90cc240be050e4fb85c22dab991d50"},
+]
+
+[package.extras]
+core = ["tree-sitter (>=0.24,<1.0)"]
+
+[[package]]
+name = "tree-sitter-language-pack"
+version = "0.13.0"
+description = "Comprehensive collection of 160+ tree-sitter language parsers"
+optional = false
+python-versions = ">=3.10.0"
+groups = ["main"]
+files = [
+    {file = "tree_sitter_language_pack-0.13.0-cp310-abi3-macosx_10_15_universal2.whl", hash = "sha256:0e7eae812b40a2dc8a12eb2f5c55e130eb892706a0bee06215dd76affeb00d07"},
+    {file = "tree_sitter_language_pack-0.13.0-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:7fdacf383418a845b20772118fcb53ad245f9c5d409bd07dae16acec65151756"},
+    {file = "tree_sitter_language_pack-0.13.0-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:0d4f261fce387ae040dae7e4d1c1aca63d84c88320afcc0961c123bec0be8377"},
+    {file = "tree_sitter_language_pack-0.13.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:78f369dc4d456c5b08d659939e662c2f9b9fba8c0ec5538a1f973e01edfcf04d"},
+    {file = "tree_sitter_language_pack-0.13.0-cp310-abi3-win_amd64.whl", hash = "sha256:1cdbc88a03dacd47bec69e56cc20c48eace1fbb6f01371e89c3ee6a2e8f34db1"},
+    {file = "tree_sitter_language_pack-0.13.0.tar.gz", hash = "sha256:032034c5e27b1f6e00730b9e7c2dbc8203b4700d0c681fd019d6defcf61183ec"},
+]
+
+[package.dependencies]
+tree-sitter = ">=0.25.2"
+tree-sitter-c-sharp = ">=0.23.1"
+tree-sitter-embedded-template = ">=0.25.0"
+tree-sitter-yaml = ">=0.7.2"
+
+[[package]]
+name = "tree-sitter-yaml"
+version = "0.7.2"
+description = "YAML grammar for tree-sitter"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "tree_sitter_yaml-0.7.2-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:7e269ddcfcab8edb14fbb1f1d34eed1e1e26888f78f94eedfe7cc98c60f8bc9f"},
+    {file = "tree_sitter_yaml-0.7.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:0807b7966e23ddf7dddc4545216e28b5a58cdadedcecca86b8d8c74271a07870"},
+    {file = "tree_sitter_yaml-0.7.2-cp310-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f1a5c60c98b6c4c037aae023569f020d0c489fad8dc26fdfd5510363c9c29a41"},
+    {file = "tree_sitter_yaml-0.7.2-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:88636d19d0654fd24f4f242eaaafa90f6f5ebdba8a62e4b32d251ed156c51a2a"},
+    {file = "tree_sitter_yaml-0.7.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1d2e8f0bb14aa4537320952d0f9607eef3021d5aada8383c34ebeece17db1e06"},
+    {file = "tree_sitter_yaml-0.7.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:74ca712c50fc9d7dbc68cb36b4a7811d6e67a5466b5a789f19bf8dd6084ef752"},
+    {file = "tree_sitter_yaml-0.7.2-cp310-abi3-win_amd64.whl", hash = "sha256:7587b5ca00fc4f9a548eff649697a3b395370b2304b399ceefa2087d8a6c9186"},
+    {file = "tree_sitter_yaml-0.7.2-cp310-abi3-win_arm64.whl", hash = "sha256:f63c227b18e7ce7587bce124578f0bbf1f890ac63d3e3cd027417574273642c4"},
+    {file = "tree_sitter_yaml-0.7.2.tar.gz", hash = "sha256:756db4c09c9d9e97c81699e8f941cb8ce4e51104927f6090eefe638ee567d32c"},
+]
+
+[package.extras]
+core = ["tree-sitter (>=0.24,<1.0)"]
+
+[[package]]
 name = "typer"
 version = "0.24.1"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
@@ -2882,6 +3378,19 @@ files = [
 
 [package.dependencies]
 typing-extensions = ">=4.12.0"
+
+[[package]]
+name = "tzdata"
+version = "2025.3"
+description = "Provider of IANA time zone data"
+optional = false
+python-versions = ">=2"
+groups = ["main"]
+markers = "sys_platform == \"win32\" or sys_platform == \"emscripten\""
+files = [
+    {file = "tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1"},
+    {file = "tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7"},
+]
 
 [[package]]
 name = "urllib3"
@@ -3079,4 +3588,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "f3037b5efb960d5c9a51b5804ea8a6ca32659b5df4fb6bb33fe7f819ae4eadd5"
+content-hash = "deafef754b71d71e211232c7aefeb425cd41840124268c0b517474008b8166f5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,10 @@ ollama = ">=0.3.0"
 litellm = "^1.82.0"
 instructor = "^1.14.5"
 prompt-toolkit = "^3.0.52"
+lancedb = "0.25.3"
+tree-sitter = ">=0.23.0"
+tree-sitter-language-pack = ">=0.6.0"
+pandas = "^3.0.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8.0.0"

--- a/src/mita/agent/loop.py
+++ b/src/mita/agent/loop.py
@@ -62,6 +62,24 @@ async def run_agent(
     # Add user message
     conversation.add(Message(role=Role.USER, content=user_prompt))
 
+    # Inject RAG context if index is available
+    if config.index.enabled:
+        try:
+            from mita.index.retriever import Retriever
+
+            retriever = Retriever(config)
+            if retriever.is_available():
+                rag_context = await retriever.retrieve_formatted(user_prompt)
+                if rag_context:
+                    conversation.add(
+                        Message(
+                            role=Role.SYSTEM,
+                            content=f"Relevant code from the project index:\n{rag_context}",
+                        )
+                    )
+        except Exception:  # noqa: BLE001
+            pass  # Index unavailable; proceed without RAG
+
     # Agent loop
     for iteration in range(MAX_ITERATIONS):
         # Truncate to fit context window

--- a/src/mita/agent/loop.py
+++ b/src/mita/agent/loop.py
@@ -27,6 +27,7 @@ from mita.ui.display import (
 from mita.ui.spinner import thinking_spinner
 
 MAX_ITERATIONS = 25
+_RAG_CONTEXT_PREFIX = "Relevant code from the project index:"
 
 
 async def run_agent(
@@ -62,7 +63,7 @@ async def run_agent(
     # Add user message
     conversation.add(Message(role=Role.USER, content=user_prompt))
 
-    # Inject RAG context if index is available
+    # Inject RAG context if index is available (replace previous RAG message)
     if config.index.enabled:
         try:
             from mita.index.retriever import Retriever
@@ -71,13 +72,19 @@ async def run_agent(
             if retriever.is_available():
                 rag_context = await retriever.retrieve_formatted(user_prompt)
                 if rag_context:
+                    # Remove any previous RAG context message
+                    conversation.messages = [
+                        m
+                        for m in conversation.messages
+                        if not (m.role == Role.SYSTEM and m.content.startswith(_RAG_CONTEXT_PREFIX))
+                    ]
                     conversation.add(
                         Message(
                             role=Role.SYSTEM,
-                            content=f"Relevant code from the project index:\n{rag_context}",
+                            content=f"{_RAG_CONTEXT_PREFIX}\n{rag_context}",
                         )
                     )
-        except Exception:  # noqa: BLE001
+        except (ConnectionError, FileNotFoundError, ImportError, OSError):
             pass  # Index unavailable; proceed without RAG
 
     # Agent loop

--- a/src/mita/cli.py
+++ b/src/mita/cli.py
@@ -192,6 +192,57 @@ def models_hardware() -> None:
     show_hardware()
 
 
+# ── Index commands ────────────────────────────────────────────────
+
+index_app = typer.Typer(help="Codebase index management.")
+app.add_typer(index_app, name="index")
+
+
+@index_app.command("build")
+def index_build(
+    force: Annotated[bool, typer.Option("--force", "-f", help="Force rebuild the index.")] = False,
+) -> None:
+    """Build the codebase index."""
+    import asyncio
+
+    from mita.index.manager import build_index
+
+    asyncio.run(build_index(force=force))
+
+
+@index_app.command("status")
+def index_status() -> None:
+    """Show index statistics."""
+    import asyncio
+
+    from mita.index.manager import show_index_status
+
+    asyncio.run(show_index_status())
+
+
+@index_app.command("search")
+def index_search(
+    query: Annotated[str, typer.Argument(help="Search query.")],
+    top_k: Annotated[int, typer.Option("--top-k", "-k", help="Number of results.")] = 10,
+) -> None:
+    """Search the codebase index."""
+    import asyncio
+
+    from mita.index.manager import search_index
+
+    asyncio.run(search_index(query, top_k=top_k))
+
+
+@index_app.command("clear")
+def index_clear() -> None:
+    """Delete the codebase index."""
+    import asyncio
+
+    from mita.index.manager import clear_index
+
+    asyncio.run(clear_index())
+
+
 # ── Chat / Ask commands ───────────────────────────────────────────
 
 

--- a/src/mita/cli.py
+++ b/src/mita/cli.py
@@ -207,7 +207,27 @@ def index_build(
 
     from mita.index.manager import build_index
 
-    asyncio.run(build_index(force=force))
+    async def _ensure_model(config: object) -> bool:
+        """Pull the embedding model if missing. Lives in cli.py to respect dependency rules."""
+        from mita.config.schema import MitaConfig
+        from mita.index.embeddings import EmbeddingClient
+        from mita.models.ollama_client import OllamaClient
+
+        assert isinstance(config, MitaConfig)
+        embedder = EmbeddingClient(config)
+        console.print(f"[yellow]Embedding model '{embedder.model}' is not installed.[/yellow]")
+        confirm = console.input(f"Pull '{embedder.model}' now? [Y/n] ").strip().lower()
+        if confirm not in ("", "y", "yes"):
+            console.print("[red]Cannot build index without embedding model.[/red]")
+            return False
+        client = OllamaClient(host=config.ollama.host)
+        console.print(f"Pulling {embedder.model}...")
+        for _progress in client.pull(embedder.model):
+            pass
+        console.print("[green]Model pulled successfully.[/green]")
+        return True
+
+    asyncio.run(build_index(force=force, pull_model_fn=_ensure_model))
 
 
 @index_app.command("status")

--- a/src/mita/config/schema.py
+++ b/src/mita/config/schema.py
@@ -50,6 +50,7 @@ class IndexSettings(BaseModel):
     exclude_patterns: list[str] = Field(
         default_factory=lambda: [
             "*.lock",
+            ".mita/**",
             "node_modules/**",
             ".git/**",
             "*.min.js",

--- a/src/mita/index/__init__.py
+++ b/src/mita/index/__init__.py
@@ -1,0 +1,1 @@
+"""Codebase indexing: Tree-sitter parsing, embeddings, LanceDB vector store."""

--- a/src/mita/index/embeddings.py
+++ b/src/mita/index/embeddings.py
@@ -1,0 +1,49 @@
+"""Embedding generation via Ollama for code chunks."""
+
+from __future__ import annotations
+
+import ollama
+
+from mita.config.schema import MitaConfig
+
+BATCH_SIZE = 32
+
+
+class EmbeddingClient:
+    """Generate embeddings using Ollama's embedding endpoint."""
+
+    def __init__(self, config: MitaConfig) -> None:
+        self._model = config.model.embedding
+        self._client = ollama.AsyncClient(host=config.ollama.host)
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    async def embed_texts(self, texts: list[str]) -> list[list[float]]:
+        """Generate embeddings for a batch of texts."""
+        all_embeddings: list[list[float]] = []
+        for i in range(0, len(texts), BATCH_SIZE):
+            batch = texts[i : i + BATCH_SIZE]
+            response = await self._client.embed(model=self._model, input=batch)
+            all_embeddings.extend(list(e) for e in response.embeddings)
+        return all_embeddings
+
+    async def embed_single(self, text: str) -> list[float]:
+        """Generate embedding for a single text."""
+        response = await self._client.embed(model=self._model, input=[text])
+        return list(response.embeddings[0])
+
+    async def is_model_available(self) -> bool:
+        """Check if the embedding model is pulled in Ollama."""
+        try:
+            models = await self._client.list()
+            model_names = [m.model for m in models.models]
+            # Check both exact match and base name (without tag)
+            base_name = self._model.split(":")[0]
+            return any(
+                m == self._model or (m is not None and m.startswith(base_name + ":"))
+                for m in model_names
+            )
+        except Exception:  # noqa: BLE001
+            return False

--- a/src/mita/index/manager.py
+++ b/src/mita/index/manager.py
@@ -1,0 +1,170 @@
+"""CLI command handlers for codebase indexing."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from rich.console import Console
+from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn
+from rich.syntax import Syntax
+from rich.table import Table
+
+from mita.config.loader import load_config
+from mita.index.embeddings import EmbeddingClient
+from mita.index.parser import parse_codebase
+from mita.index.retriever import Retriever
+from mita.index.store import IndexStore
+
+console = Console()
+
+
+def _get_index_dir() -> Path:
+    return Path.cwd() / ".mita" / "index"
+
+
+async def build_index(force: bool = False) -> None:
+    """Build the codebase index."""
+    config = load_config()
+    index_dir = _get_index_dir()
+    store = IndexStore(index_dir)
+
+    # Check if index already exists
+    if store.exists() and not force:
+        console.print("[yellow]Index already exists. Use --force to rebuild.[/yellow]")
+        return
+
+    # Check embedding model availability
+    embedder = EmbeddingClient(config)
+    if not await embedder.is_model_available():
+        console.print(f"[yellow]Embedding model '{embedder.model}' is not installed.[/yellow]")
+        confirm = console.input(f"Pull '{embedder.model}' now? [Y/n] ").strip().lower()
+        if confirm in ("", "y", "yes"):
+            from mita.models.ollama_client import OllamaClient
+
+            client = OllamaClient(host=config.ollama.host)
+            console.print(f"Pulling {embedder.model}...")
+            for _progress in client.pull(embedder.model):
+                pass
+            console.print("[green]Model pulled successfully.[/green]")
+        else:
+            console.print("[red]Cannot build index without embedding model.[/red]")
+            return
+
+    start_time = time.monotonic()
+
+    # Parse codebase
+    root = Path.cwd()
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        console=console,
+    ) as progress:
+        progress.add_task("Parsing codebase...", total=None)
+        chunks = parse_codebase(root, config.index)
+
+    if not chunks:
+        console.print("[yellow]No code chunks found to index.[/yellow]")
+        return
+
+    console.print(f"Found {len(chunks)} chunks from codebase.")
+
+    # Generate embeddings
+    texts = [c.content for c in chunks]
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        TextColumn("{task.completed}/{task.total}"),
+        console=console,
+    ) as progress:
+        task = progress.add_task("Generating embeddings...", total=len(texts))
+        embeddings = []
+        batch_size = 32
+        for i in range(0, len(texts), batch_size):
+            batch = texts[i : i + batch_size]
+            batch_embeddings = await embedder.embed_texts(batch)
+            embeddings.extend(batch_embeddings)
+            progress.update(task, completed=min(i + batch_size, len(texts)))
+
+    # Attach embeddings to chunks
+    for chunk, embedding in zip(chunks, embeddings):
+        chunk.embedding = embedding
+
+    # Store in LanceDB
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        console=console,
+    ) as progress:
+        progress.add_task("Writing index...", total=None)
+        await store.create_or_replace(chunks)
+
+    elapsed = time.monotonic() - start_time
+    file_count = len({c.file_path for c in chunks})
+    console.print(
+        f"[green]Indexed {len(chunks)} chunks from {file_count} files in {elapsed:.1f}s.[/green]"
+    )
+
+
+async def show_index_status() -> None:
+    """Show index statistics."""
+    config = load_config()
+    store = IndexStore(_get_index_dir())
+    stats = await store.status()
+
+    if not stats["exists"]:
+        console.print("[yellow]No index found. Run 'mita index build' first.[/yellow]")
+        return
+
+    table = Table(title="Index Status")
+    table.add_column("Metric", style="bold")
+    table.add_column("Value")
+    table.add_row("Chunks", str(stats["chunks"]))
+    table.add_row("Files", str(stats["files"]))
+    table.add_row("Location", str(_get_index_dir()))
+    table.add_row("Embedding model", config.model.embedding)
+    console.print(table)
+
+
+async def search_index(query: str, top_k: int = 10) -> None:
+    """Search the index and display results."""
+    config = load_config()
+    retriever = Retriever(config, index_dir=_get_index_dir())
+
+    if not retriever.is_available():
+        console.print("[yellow]No index found. Run 'mita index build' first.[/yellow]")
+        return
+
+    results = await retriever.retrieve(query, top_k=top_k)
+
+    if not results:
+        console.print("[yellow]No results found.[/yellow]")
+        return
+
+    console.print(f"[bold]Found {len(results)} results:[/bold]\n")
+    for i, r in enumerate(results, 1):
+        c = r.chunk
+        header = f"{i}. {c.file_path}:{c.start_line}-{c.end_line}"
+        if c.symbol:
+            header += f" ({c.symbol})"
+        header += f"  [dim]score: {r.score:.3f}[/dim]"
+        console.print(header)
+        console.print(Syntax(c.content, c.language, line_numbers=True, start_line=c.start_line))
+        console.print()
+
+
+async def clear_index() -> None:
+    """Clear the index."""
+    store = IndexStore(_get_index_dir())
+
+    if not store.exists():
+        console.print("[yellow]No index found.[/yellow]")
+        return
+
+    confirm = console.input("Delete the index? [y/N] ").strip().lower()
+    if confirm in ("y", "yes"):
+        await store.clear()
+        console.print("[green]Index cleared.[/green]")
+    else:
+        console.print("Cancelled.")

--- a/src/mita/index/manager.py
+++ b/src/mita/index/manager.py
@@ -23,8 +23,15 @@ def _get_index_dir() -> Path:
     return Path.cwd() / ".mita" / "index"
 
 
-async def build_index(force: bool = False) -> None:
-    """Build the codebase index."""
+async def build_index(force: bool = False, pull_model_fn: object | None = None) -> None:
+    """Build the codebase index.
+
+    Args:
+        force: Rebuild even if index already exists.
+        pull_model_fn: Async callback to pull the embedding model if missing.
+            Signature: async (MitaConfig) -> bool. Called from the CLI layer
+            so it can import from mita.models without violating dependency rules.
+    """
     config = load_config()
     index_dir = _get_index_dir()
     store = IndexStore(index_dir)
@@ -37,18 +44,11 @@ async def build_index(force: bool = False) -> None:
     # Check embedding model availability
     embedder = EmbeddingClient(config)
     if not await embedder.is_model_available():
-        console.print(f"[yellow]Embedding model '{embedder.model}' is not installed.[/yellow]")
-        confirm = console.input(f"Pull '{embedder.model}' now? [Y/n] ").strip().lower()
-        if confirm in ("", "y", "yes"):
-            from mita.models.ollama_client import OllamaClient
-
-            client = OllamaClient(host=config.ollama.host)
-            console.print(f"Pulling {embedder.model}...")
-            for _progress in client.pull(embedder.model):
-                pass
-            console.print("[green]Model pulled successfully.[/green]")
+        if pull_model_fn is not None:
+            if not await pull_model_fn(config):  # type: ignore[operator]
+                return
         else:
-            console.print("[red]Cannot build index without embedding model.[/red]")
+            console.print("[red]Embedding model not available.[/red]")
             return
 
     start_time = time.monotonic()

--- a/src/mita/index/parser.py
+++ b/src/mita/index/parser.py
@@ -1,0 +1,331 @@
+"""Tree-sitter code parsing and chunking for codebase indexing."""
+
+from __future__ import annotations
+
+from fnmatch import fnmatch
+from pathlib import Path
+from typing import Any
+
+from mita.config.schema import IndexSettings
+from mita.index.store import CodeChunk
+
+# Extension → tree-sitter language name
+EXTENSION_MAP: dict[str, str] = {
+    ".py": "python",
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".ts": "typescript",
+    ".tsx": "tsx",
+    ".go": "go",
+    ".rs": "rust",
+    ".java": "java",
+    ".c": "c",
+    ".h": "c",
+    ".cpp": "cpp",
+    ".hpp": "cpp",
+    ".cc": "cpp",
+    ".rb": "ruby",
+    ".php": "php",
+    ".swift": "swift",
+    ".kt": "kotlin",
+    ".scala": "scala",
+    ".lua": "lua",
+    ".sh": "bash",
+    ".bash": "bash",
+    ".zsh": "bash",
+    ".css": "css",
+    ".html": "html",
+    ".json": "json",
+    ".yaml": "yaml",
+    ".yml": "yaml",
+    ".toml": "toml",
+}
+
+# Node types that represent semantic code units per language
+CHUNK_NODE_TYPES: dict[str, set[str]] = {
+    "python": {"function_definition", "class_definition", "decorated_definition"},
+    "javascript": {
+        "function_declaration",
+        "class_declaration",
+        "method_definition",
+        "export_statement",
+    },
+    "typescript": {
+        "function_declaration",
+        "class_declaration",
+        "method_definition",
+        "export_statement",
+        "interface_declaration",
+        "type_alias_declaration",
+    },
+    "tsx": {
+        "function_declaration",
+        "class_declaration",
+        "method_definition",
+        "export_statement",
+        "interface_declaration",
+        "type_alias_declaration",
+    },
+    "go": {"function_declaration", "method_declaration", "type_declaration"},
+    "rust": {"function_item", "impl_item", "struct_item", "enum_item", "trait_item"},
+    "java": {"class_declaration", "method_declaration", "interface_declaration"},
+    "c": {"function_definition", "struct_specifier"},
+    "cpp": {"function_definition", "class_specifier", "struct_specifier"},
+    "ruby": {"method", "class", "module"},
+}
+
+
+def parse_codebase(root: Path, config: IndexSettings) -> list[CodeChunk]:
+    """Parse all supported files under root into code chunks."""
+    chunks: list[CodeChunk] = []
+    for file_path in _discover_files(root, config.exclude_patterns):
+        file_chunks = parse_file(file_path, root, config)
+        chunks.extend(file_chunks)
+    return chunks
+
+
+def parse_file(file_path: Path, root: Path, config: IndexSettings) -> list[CodeChunk]:
+    """Parse a single file into code chunks."""
+    if _is_binary(file_path):
+        return []
+
+    try:
+        content = file_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+
+    if not content.strip():
+        return []
+
+    rel_path = str(file_path.relative_to(root))
+    language = get_language_for_file(file_path)
+
+    if language and language in CHUNK_NODE_TYPES:
+        chunks = _parse_with_treesitter(content, rel_path, language, config)
+        if chunks:
+            return chunks
+
+    # Fallback: line-based chunking
+    return _chunk_by_lines(content, rel_path, language or "text", config)
+
+
+def get_language_for_file(path: Path) -> str | None:
+    """Map a file extension to a tree-sitter language name."""
+    return EXTENSION_MAP.get(path.suffix.lower())
+
+
+def _discover_files(root: Path, exclude_patterns: list[str]) -> list[Path]:
+    """Walk the project and yield non-excluded files."""
+    files = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = str(path.relative_to(root))
+        if _matches_exclude(rel, exclude_patterns):
+            continue
+        files.append(path)
+    return files
+
+
+def _matches_exclude(rel_path: str, patterns: list[str]) -> bool:
+    """Check if a relative path matches any exclude pattern."""
+    for pattern in patterns:
+        if fnmatch(rel_path, pattern):
+            return True
+        # Also check each path component for directory patterns
+        parts = rel_path.split("/")
+        for i in range(len(parts)):
+            partial = "/".join(parts[: i + 1])
+            if fnmatch(partial, pattern.rstrip("/")):
+                return True
+            if fnmatch(partial + "/", pattern):
+                return True
+    return False
+
+
+def _is_binary(path: Path) -> bool:
+    """Heuristic: file is binary if first 8KB contains null bytes."""
+    try:
+        with open(path, "rb") as f:
+            chunk = f.read(8192)
+        return b"\x00" in chunk
+    except OSError:
+        return True
+
+
+def _parse_with_treesitter(
+    content: str,
+    rel_path: str,
+    language: str,
+    config: IndexSettings,
+) -> list[CodeChunk]:
+    """Parse a file using tree-sitter and extract semantic chunks."""
+    try:
+        from tree_sitter_language_pack import get_parser
+    except ImportError:
+        return []
+
+    try:
+        parser = get_parser(language)  # type: ignore[arg-type]
+    except Exception:  # noqa: BLE001
+        return []
+
+    tree = parser.parse(content.encode("utf-8"))
+    node_types = CHUNK_NODE_TYPES.get(language, set())
+    lines = content.split("\n")
+    chunks: list[CodeChunk] = []
+
+    for node in _walk_top_level(tree.root_node):
+        if node.type not in node_types:
+            continue
+
+        start_line = node.start_point[0] + 1  # 1-indexed
+        end_line = node.end_point[0] + 1
+        node_content = "\n".join(lines[start_line - 1 : end_line])
+        symbol = _extract_symbol(node, language)
+
+        # Split large nodes
+        char_budget = config.chunk_size * 4  # ~4 chars per token
+        if len(node_content) > char_budget:
+            sub_chunks = _split_large_content(
+                node_content, start_line, rel_path, language, symbol, config
+            )
+            chunks.extend(sub_chunks)
+        else:
+            chunks.append(
+                CodeChunk(
+                    file_path=rel_path,
+                    start_line=start_line,
+                    end_line=end_line,
+                    content=node_content,
+                    language=language,
+                    symbol=symbol,
+                )
+            )
+
+    return chunks
+
+
+def _walk_top_level(node: Any) -> list[Any]:
+    """Get top-level children of the root node (non-recursive)."""
+    children = getattr(node, "children", [])
+    return list(children)
+
+
+def _extract_symbol(node: Any, language: str) -> str | None:
+    """Extract the name of a function/class node."""
+    # Most languages store the name in a child node of type "identifier" or "name"
+    for child in getattr(node, "children", []):
+        child_type = getattr(child, "type", "")
+        if child_type in ("identifier", "name", "property_identifier"):
+            return getattr(child, "text", b"").decode("utf-8", errors="replace")
+    return None
+
+
+def _split_large_content(
+    content: str,
+    base_start_line: int,
+    rel_path: str,
+    language: str,
+    symbol: str | None,
+    config: IndexSettings,
+) -> list[CodeChunk]:
+    """Split a large chunk into overlapping sub-chunks."""
+    lines = content.split("\n")
+    char_budget = config.chunk_size * 4
+    overlap_chars = config.chunk_overlap * 4
+    chunks: list[CodeChunk] = []
+
+    start = 0
+    while start < len(lines):
+        # Accumulate lines until we hit the budget
+        end = start
+        total_chars = 0
+        while end < len(lines) and total_chars < char_budget:
+            total_chars += len(lines[end]) + 1
+            end += 1
+
+        chunk_content = "\n".join(lines[start:end])
+        chunks.append(
+            CodeChunk(
+                file_path=rel_path,
+                start_line=base_start_line + start,
+                end_line=base_start_line + end - 1,
+                content=chunk_content,
+                language=language,
+                symbol=symbol,
+            )
+        )
+
+        # If we consumed all lines, we're done
+        if end >= len(lines):
+            break
+
+        # Advance with overlap
+        overlap_lines = 0
+        overlap_total = 0
+        for i in range(end - 1, start, -1):
+            overlap_total += len(lines[i]) + 1
+            overlap_lines += 1
+            if overlap_total >= overlap_chars:
+                break
+
+        new_start = end - overlap_lines
+        if new_start <= start:
+            break
+        start = new_start
+
+    return chunks
+
+
+def _chunk_by_lines(
+    content: str,
+    rel_path: str,
+    language: str,
+    config: IndexSettings,
+) -> list[CodeChunk]:
+    """Fallback: chunk file by line windows."""
+    lines = content.split("\n")
+    char_budget = config.chunk_size * 4
+    overlap_chars = config.chunk_overlap * 4
+    chunks: list[CodeChunk] = []
+
+    start = 0
+    while start < len(lines):
+        end = start
+        total_chars = 0
+        while end < len(lines) and total_chars < char_budget:
+            total_chars += len(lines[end]) + 1
+            end += 1
+
+        chunk_content = "\n".join(lines[start:end])
+        if chunk_content.strip():
+            chunks.append(
+                CodeChunk(
+                    file_path=rel_path,
+                    start_line=start + 1,
+                    end_line=end,
+                    content=chunk_content,
+                    language=language,
+                )
+            )
+
+        # If we consumed all lines, we're done
+        if end >= len(lines):
+            break
+
+        # Advance with overlap
+        overlap_lines = 0
+        overlap_total = 0
+        for i in range(end - 1, start, -1):
+            overlap_total += len(lines[i]) + 1
+            overlap_lines += 1
+            if overlap_total >= overlap_chars:
+                break
+
+        new_start = end - overlap_lines
+        if new_start <= start:
+            break
+        start = new_start
+
+    return chunks

--- a/src/mita/index/retriever.py
+++ b/src/mita/index/retriever.py
@@ -1,0 +1,53 @@
+"""RAG retrieval pipeline: vector search over indexed code chunks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from mita.config.schema import MitaConfig
+from mita.index.embeddings import EmbeddingClient
+from mita.index.store import IndexStore, SearchResult
+
+
+def _default_index_dir() -> Path:
+    """Determine the index directory for the current project."""
+    return Path.cwd() / ".mita" / "index"
+
+
+class Retriever:
+    """High-level retrieval combining embeddings + vector search."""
+
+    def __init__(self, config: MitaConfig, index_dir: Path | None = None) -> None:
+        self._config = config
+        self._index_dir = index_dir or _default_index_dir()
+        self._store = IndexStore(self._index_dir)
+        self._embedder = EmbeddingClient(config)
+
+    async def retrieve(self, query: str, top_k: int | None = None) -> list[SearchResult]:
+        """Retrieve relevant code chunks for a query."""
+        k = top_k or self._config.index.top_k
+        query_embedding = await self._embedder.embed_single(query)
+        return await self._store.search(query_embedding, top_k=k)
+
+    async def retrieve_formatted(self, query: str, top_k: int | None = None) -> str:
+        """Retrieve and format results as a context string for the LLM."""
+        results = await self.retrieve(query, top_k=top_k)
+        if not results:
+            return ""
+        return format_results(results)
+
+    def is_available(self) -> bool:
+        """Check if the index exists and is ready to query."""
+        return self._store.exists()
+
+
+def format_results(results: list[SearchResult]) -> str:
+    """Format search results as a readable context block."""
+    parts: list[str] = []
+    for r in results:
+        c = r.chunk
+        header = f"## {c.file_path}:{c.start_line}-{c.end_line}"
+        if c.symbol:
+            header += f" ({c.symbol})"
+        parts.append(f"{header}\n```{c.language}\n{c.content}\n```")
+    return "\n\n".join(parts)

--- a/src/mita/index/store.py
+++ b/src/mita/index/store.py
@@ -1,0 +1,143 @@
+"""LanceDB vector store operations for code chunk storage and retrieval."""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+from pathlib import Path
+from typing import Any
+
+import lancedb  # type: ignore[import-untyped]
+from pydantic import BaseModel, Field
+
+
+class CodeChunk(BaseModel):
+    """A chunk of code extracted from a source file."""
+
+    file_path: str
+    start_line: int
+    end_line: int
+    content: str
+    language: str
+    symbol: str | None = None
+    embedding: list[float] | None = Field(default=None, exclude=True)
+
+
+class SearchResult(BaseModel):
+    """A code chunk with its similarity score."""
+
+    chunk: CodeChunk
+    score: float
+
+
+class IndexStore:
+    """LanceDB-backed vector store for code chunks."""
+
+    TABLE_NAME = "code_chunks"
+
+    def __init__(self, index_dir: Path) -> None:
+        self._index_dir = index_dir
+        self._db_path = index_dir / "lancedb"
+
+    def _connect(self) -> lancedb.DBConnection:
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        return lancedb.connect(str(self._db_path))
+
+    async def create_or_replace(self, chunks: list[CodeChunk]) -> None:
+        """Create or replace the index with the given chunks."""
+        if not chunks:
+            return
+
+        def _sync() -> None:
+            db = self._connect()
+            records = _chunks_to_records(chunks)
+            if self.TABLE_NAME in db.table_names():
+                db.drop_table(self.TABLE_NAME)
+            db.create_table(self.TABLE_NAME, data=records)
+
+        await asyncio.to_thread(_sync)
+
+    async def search(self, query_embedding: list[float], top_k: int = 10) -> list[SearchResult]:
+        """Vector similarity search."""
+
+        def _sync() -> list[SearchResult]:
+            db = self._connect()
+            if self.TABLE_NAME not in db.table_names():
+                return []
+            table = db.open_table(self.TABLE_NAME)
+            results = table.search(query_embedding).limit(top_k).to_pandas()
+
+            search_results: list[SearchResult] = []
+            for _, row in results.iterrows():
+                distance = row.get("_distance", 0.0)
+                score = 1.0 / (1.0 + distance)
+                chunk = CodeChunk(
+                    file_path=row["file_path"],
+                    start_line=int(row["start_line"]),
+                    end_line=int(row["end_line"]),
+                    content=row["content"],
+                    language=row["language"],
+                    symbol=row.get("symbol"),
+                )
+                search_results.append(SearchResult(chunk=chunk, score=score))
+            return search_results
+
+        return await asyncio.to_thread(_sync)
+
+    async def clear(self) -> None:
+        """Delete the entire index."""
+
+        def _sync() -> None:
+            if self._db_path.exists():
+                shutil.rmtree(self._db_path)
+
+        await asyncio.to_thread(_sync)
+
+    async def status(self) -> dict[str, Any]:
+        """Return index statistics."""
+
+        def _sync() -> dict[str, Any]:
+            if not self._db_path.exists():
+                return {"exists": False, "chunks": 0, "files": 0}
+            db = self._connect()
+            if self.TABLE_NAME not in db.table_names():
+                return {"exists": False, "chunks": 0, "files": 0}
+            table = db.open_table(self.TABLE_NAME)
+            df = table.to_pandas()
+            return {
+                "exists": True,
+                "chunks": len(df),
+                "files": df["file_path"].nunique() if len(df) > 0 else 0,
+            }
+
+        return await asyncio.to_thread(_sync)
+
+    def exists(self) -> bool:
+        """Check if the index exists on disk."""
+        if not self._db_path.exists():
+            return False
+        try:
+            db = self._connect()
+            return self.TABLE_NAME in db.table_names()
+        except Exception:  # noqa: BLE001
+            return False
+
+
+def _chunks_to_records(chunks: list[CodeChunk]) -> list[dict[str, Any]]:
+    """Convert CodeChunks (with embeddings) to LanceDB-compatible records."""
+    records = []
+    for chunk in chunks:
+        if chunk.embedding is None:
+            continue
+        records.append(
+            {
+                "file_path": chunk.file_path,
+                "start_line": chunk.start_line,
+                "end_line": chunk.end_line,
+                "content": chunk.content,
+                "language": chunk.language,
+                "symbol": chunk.symbol or "",
+                "vector": chunk.embedding,
+            }
+        )
+    return records

--- a/tests/test_index/test_embeddings.py
+++ b/tests/test_index/test_embeddings.py
@@ -1,0 +1,100 @@
+"""Tests for embedding generation via Ollama."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from mita.config.schema import MitaConfig
+from mita.index.embeddings import BATCH_SIZE, EmbeddingClient
+
+
+def _mock_embed_response(embeddings: list[list[float]]) -> MagicMock:
+    resp = MagicMock()
+    resp.embeddings = embeddings
+    return resp
+
+
+class TestEmbedTexts:
+    @pytest.mark.asyncio()
+    async def test_single_batch(self) -> None:
+        config = MitaConfig()
+        client = EmbeddingClient(config)
+        mock_embed = AsyncMock(return_value=_mock_embed_response([[0.1, 0.2], [0.3, 0.4]]))
+        client._client.embed = mock_embed
+
+        result = await client.embed_texts(["text1", "text2"])
+        assert len(result) == 2
+        assert result[0] == [0.1, 0.2]
+        mock_embed.assert_called_once()
+
+    @pytest.mark.asyncio()
+    async def test_multiple_batches(self) -> None:
+        config = MitaConfig()
+        client = EmbeddingClient(config)
+        texts = [f"text{i}" for i in range(BATCH_SIZE + 5)]
+
+        batch1_embs = [[float(i)] for i in range(BATCH_SIZE)]
+        batch2_embs = [[float(i)] for i in range(BATCH_SIZE, BATCH_SIZE + 5)]
+
+        mock_embed = AsyncMock(
+            side_effect=[
+                _mock_embed_response(batch1_embs),
+                _mock_embed_response(batch2_embs),
+            ]
+        )
+        client._client.embed = mock_embed
+
+        result = await client.embed_texts(texts)
+        assert len(result) == BATCH_SIZE + 5
+        assert mock_embed.call_count == 2
+
+
+class TestEmbedSingle:
+    @pytest.mark.asyncio()
+    async def test_returns_single_embedding(self) -> None:
+        config = MitaConfig()
+        client = EmbeddingClient(config)
+        mock_embed = AsyncMock(return_value=_mock_embed_response([[0.5, 0.6, 0.7]]))
+        client._client.embed = mock_embed
+
+        result = await client.embed_single("hello world")
+        assert result == [0.5, 0.6, 0.7]
+        mock_embed.assert_called_once()
+
+
+class TestModelAvailability:
+    @pytest.mark.asyncio()
+    async def test_available(self) -> None:
+        config = MitaConfig()
+        client = EmbeddingClient(config)
+
+        model = MagicMock()
+        model.model = "nomic-embed-text:latest"
+        models_resp = MagicMock()
+        models_resp.models = [model]
+        client._client.list = AsyncMock(return_value=models_resp)
+
+        assert await client.is_model_available()
+
+    @pytest.mark.asyncio()
+    async def test_not_available(self) -> None:
+        config = MitaConfig()
+        client = EmbeddingClient(config)
+
+        model = MagicMock()
+        model.model = "llama3:latest"
+        models_resp = MagicMock()
+        models_resp.models = [model]
+        client._client.list = AsyncMock(return_value=models_resp)
+
+        assert not await client.is_model_available()
+
+    @pytest.mark.asyncio()
+    async def test_connection_error(self) -> None:
+        config = MitaConfig()
+        client = EmbeddingClient(config)
+        client._client.list = AsyncMock(side_effect=ConnectionError("no server"))
+
+        assert not await client.is_model_available()

--- a/tests/test_index/test_parser.py
+++ b/tests/test_index/test_parser.py
@@ -1,0 +1,157 @@
+"""Tests for Tree-sitter code parsing and chunking."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from mita.config.schema import IndexSettings
+from mita.index.parser import (
+    _chunk_by_lines,
+    _is_binary,
+    _matches_exclude,
+    get_language_for_file,
+    parse_codebase,
+    parse_file,
+)
+
+
+class TestLanguageDetection:
+    def test_python(self) -> None:
+        assert get_language_for_file(Path("foo.py")) == "python"
+
+    def test_javascript(self) -> None:
+        assert get_language_for_file(Path("app.js")) == "javascript"
+
+    def test_typescript(self) -> None:
+        assert get_language_for_file(Path("app.ts")) == "typescript"
+
+    def test_go(self) -> None:
+        assert get_language_for_file(Path("main.go")) == "go"
+
+    def test_rust(self) -> None:
+        assert get_language_for_file(Path("lib.rs")) == "rust"
+
+    def test_unknown(self) -> None:
+        assert get_language_for_file(Path("data.xyz")) is None
+
+    def test_case_insensitive_suffix(self) -> None:
+        assert get_language_for_file(Path("file.PY")) == "python"
+
+
+class TestExcludePatterns:
+    def test_matches_lock_file(self) -> None:
+        assert _matches_exclude("poetry.lock", ["*.lock"])
+
+    def test_matches_node_modules(self) -> None:
+        assert _matches_exclude("node_modules/foo/bar.js", ["node_modules/**"])
+
+    def test_matches_git(self) -> None:
+        assert _matches_exclude(".git/config", [".git/**"])
+
+    def test_no_match(self) -> None:
+        assert not _matches_exclude("src/main.py", ["*.lock", ".git/**"])
+
+    def test_pycache(self) -> None:
+        assert _matches_exclude("__pycache__/foo.pyc", ["__pycache__/**"])
+
+
+class TestBinaryDetection:
+    def test_text_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "test.py"
+        f.write_text("print('hello')")
+        assert not _is_binary(f)
+
+    def test_binary_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "test.bin"
+        f.write_bytes(b"\x00\x01\x02\x03")
+        assert _is_binary(f)
+
+
+class TestParseFilePython:
+    def test_parses_functions(self, tmp_path: Path) -> None:
+        code = '''def hello():
+    """Say hello."""
+    print("hello")
+
+
+def goodbye():
+    """Say goodbye."""
+    print("goodbye")
+'''
+        f = tmp_path / "test.py"
+        f.write_text(code)
+        config = IndexSettings()
+        chunks = parse_file(f, tmp_path, config)
+        assert len(chunks) >= 2
+        # Check that chunks have correct language
+        for c in chunks:
+            assert c.language == "python"
+        # Should find function symbols
+        symbols = [c.symbol for c in chunks if c.symbol]
+        assert "hello" in symbols
+        assert "goodbye" in symbols
+
+    def test_parses_class(self, tmp_path: Path) -> None:
+        code = """class Greeter:
+    def greet(self):
+        pass
+"""
+        f = tmp_path / "test.py"
+        f.write_text(code)
+        config = IndexSettings()
+        chunks = parse_file(f, tmp_path, config)
+        assert len(chunks) >= 1
+        symbols = [c.symbol for c in chunks if c.symbol]
+        assert "Greeter" in symbols
+
+
+class TestChunkByLines:
+    def test_basic_chunking(self) -> None:
+        content = "\n".join(f"line {i}" for i in range(100))
+        config = IndexSettings(chunk_size=20, chunk_overlap=2)
+        chunks = _chunk_by_lines(content, "test.txt", "text", config)
+        assert len(chunks) > 1
+        # All chunks should have valid line numbers
+        for c in chunks:
+            assert c.start_line >= 1
+            assert c.end_line >= c.start_line
+
+    def test_small_file_single_chunk(self) -> None:
+        content = "line 1\nline 2\nline 3"
+        config = IndexSettings(chunk_size=512)
+        chunks = _chunk_by_lines(content, "test.txt", "text", config)
+        assert len(chunks) == 1
+
+    def test_empty_content_no_chunks(self) -> None:
+        config = IndexSettings()
+        chunks = _chunk_by_lines("", "test.txt", "text", config)
+        assert len(chunks) == 0
+
+
+class TestParseCodebase:
+    def test_discovers_and_parses(self, tmp_path: Path) -> None:
+        # Create a simple project
+        (tmp_path / "main.py").write_text("def main():\n    pass\n")
+        (tmp_path / "readme.md").write_text("# Hello\nThis is a project.\n")
+        (tmp_path / "data.lock").write_text("lock data")
+
+        config = IndexSettings(exclude_patterns=["*.lock"])
+        chunks = parse_codebase(tmp_path, config)
+        # Should have chunks from main.py and readme.md but not data.lock
+        file_paths = {c.file_path for c in chunks}
+        assert "main.py" in file_paths
+        assert "data.lock" not in file_paths
+
+    def test_skips_binary(self, tmp_path: Path) -> None:
+        (tmp_path / "binary.dat").write_bytes(b"\x00" * 100)
+        (tmp_path / "text.py").write_text("x = 1\n")
+
+        config = IndexSettings(exclude_patterns=[])
+        chunks = parse_codebase(tmp_path, config)
+        file_paths = {c.file_path for c in chunks}
+        assert "binary.dat" not in file_paths
+
+    def test_empty_dir(self, tmp_path: Path) -> None:
+        config = IndexSettings()
+        chunks = parse_codebase(tmp_path, config)
+        assert chunks == []

--- a/tests/test_index/test_retriever.py
+++ b/tests/test_index/test_retriever.py
@@ -1,0 +1,129 @@
+"""Tests for RAG retrieval pipeline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mita.config.schema import MitaConfig
+from mita.index.retriever import Retriever, format_results
+from mita.index.store import CodeChunk, SearchResult
+
+
+def _make_result(file_path: str = "test.py", symbol: str = "func") -> SearchResult:
+    return SearchResult(
+        chunk=CodeChunk(
+            file_path=file_path,
+            start_line=1,
+            end_line=5,
+            content="def func():\n    pass",
+            language="python",
+            symbol=symbol,
+        ),
+        score=0.95,
+    )
+
+
+class TestFormatResults:
+    def test_basic_format(self) -> None:
+        results = [_make_result()]
+        text = format_results(results)
+        assert "test.py:1-5" in text
+        assert "func" in text
+        assert "```python" in text
+
+    def test_multiple_results(self) -> None:
+        results = [_make_result("a.py", "foo"), _make_result("b.py", "bar")]
+        text = format_results(results)
+        assert "a.py" in text
+        assert "b.py" in text
+
+    def test_no_symbol(self) -> None:
+        result = SearchResult(
+            chunk=CodeChunk(
+                file_path="test.py",
+                start_line=1,
+                end_line=2,
+                content="x = 1",
+                language="python",
+            ),
+            score=0.5,
+        )
+        text = format_results([result])
+        assert "test.py:1-2" in text
+
+
+class TestRetriever:
+    @pytest.mark.asyncio()
+    async def test_retrieve(self, tmp_path: Path) -> None:
+        config = MitaConfig()
+        retriever = Retriever(config, index_dir=tmp_path)
+
+        mock_results = [_make_result()]
+        with (
+            patch.object(retriever._store, "exists", return_value=True),
+            patch.object(
+                retriever._store, "search", new_callable=AsyncMock, return_value=mock_results
+            ),
+            patch.object(
+                retriever._embedder,
+                "embed_single",
+                new_callable=AsyncMock,
+                return_value=[0.1] * 768,
+            ),
+        ):
+            results = await retriever.retrieve("test query")
+            assert len(results) == 1
+            assert results[0].chunk.file_path == "test.py"
+
+    @pytest.mark.asyncio()
+    async def test_retrieve_formatted(self, tmp_path: Path) -> None:
+        config = MitaConfig()
+        retriever = Retriever(config, index_dir=tmp_path)
+
+        mock_results = [_make_result()]
+        with (
+            patch.object(retriever._store, "exists", return_value=True),
+            patch.object(
+                retriever._store, "search", new_callable=AsyncMock, return_value=mock_results
+            ),
+            patch.object(
+                retriever._embedder,
+                "embed_single",
+                new_callable=AsyncMock,
+                return_value=[0.1] * 768,
+            ),
+        ):
+            text = await retriever.retrieve_formatted("test query")
+            assert "test.py" in text
+            assert "```python" in text
+
+    @pytest.mark.asyncio()
+    async def test_retrieve_empty(self, tmp_path: Path) -> None:
+        config = MitaConfig()
+        retriever = Retriever(config, index_dir=tmp_path)
+
+        with (
+            patch.object(retriever._store, "exists", return_value=True),
+            patch.object(retriever._store, "search", new_callable=AsyncMock, return_value=[]),
+            patch.object(
+                retriever._embedder,
+                "embed_single",
+                new_callable=AsyncMock,
+                return_value=[0.1] * 768,
+            ),
+        ):
+            text = await retriever.retrieve_formatted("test query")
+            assert text == ""
+
+    def test_is_available(self, tmp_path: Path) -> None:
+        config = MitaConfig()
+        retriever = Retriever(config, index_dir=tmp_path)
+
+        with patch.object(retriever._store, "exists", return_value=False):
+            assert not retriever.is_available()
+
+        with patch.object(retriever._store, "exists", return_value=True):
+            assert retriever.is_available()

--- a/tests/test_index/test_store.py
+++ b/tests/test_index/test_store.py
@@ -1,0 +1,137 @@
+"""Tests for LanceDB vector store operations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mita.index.store import CodeChunk, IndexStore, SearchResult
+
+
+def _make_chunk(
+    file_path: str = "test.py",
+    start_line: int = 1,
+    end_line: int = 5,
+    content: str = "def hello(): pass",
+    language: str = "python",
+    symbol: str | None = "hello",
+    embedding: list[float] | None = None,
+) -> CodeChunk:
+    return CodeChunk(
+        file_path=file_path,
+        start_line=start_line,
+        end_line=end_line,
+        content=content,
+        language=language,
+        symbol=symbol,
+        embedding=embedding,
+    )
+
+
+def _make_embedding(dim: int = 768, value: float = 0.1) -> list[float]:
+    return [value] * dim
+
+
+class TestCodeChunk:
+    def test_basic_creation(self) -> None:
+        chunk = _make_chunk()
+        assert chunk.file_path == "test.py"
+        assert chunk.language == "python"
+        assert chunk.symbol == "hello"
+
+    def test_embedding_excluded_from_dict(self) -> None:
+        chunk = _make_chunk(embedding=[0.1, 0.2])
+        d = chunk.model_dump()
+        assert "embedding" not in d
+
+
+class TestSearchResult:
+    def test_creation(self) -> None:
+        chunk = _make_chunk()
+        result = SearchResult(chunk=chunk, score=0.95)
+        assert result.score == 0.95
+        assert result.chunk.file_path == "test.py"
+
+
+class TestIndexStore:
+    @pytest.mark.asyncio()
+    async def test_create_and_search(self, tmp_path: Path) -> None:
+        store = IndexStore(tmp_path / "index")
+        emb = _make_embedding()
+        chunks = [
+            _make_chunk(file_path="a.py", symbol="func_a", embedding=emb),
+            _make_chunk(file_path="b.py", symbol="func_b", embedding=_make_embedding(value=0.9)),
+        ]
+        await store.create_or_replace(chunks)
+        assert store.exists()
+
+        # Search with a vector close to the first chunk
+        results = await store.search(emb, top_k=2)
+        assert len(results) == 2
+        assert isinstance(results[0], SearchResult)
+        assert results[0].score > 0
+
+    @pytest.mark.asyncio()
+    async def test_exists_false_initially(self, tmp_path: Path) -> None:
+        store = IndexStore(tmp_path / "index")
+        assert not store.exists()
+
+    @pytest.mark.asyncio()
+    async def test_clear(self, tmp_path: Path) -> None:
+        store = IndexStore(tmp_path / "index")
+        chunks = [_make_chunk(embedding=_make_embedding())]
+        await store.create_or_replace(chunks)
+        assert store.exists()
+
+        await store.clear()
+        assert not store.exists()
+
+    @pytest.mark.asyncio()
+    async def test_status_empty(self, tmp_path: Path) -> None:
+        store = IndexStore(tmp_path / "index")
+        stats = await store.status()
+        assert stats["exists"] is False
+        assert stats["chunks"] == 0
+
+    @pytest.mark.asyncio()
+    async def test_status_with_data(self, tmp_path: Path) -> None:
+        store = IndexStore(tmp_path / "index")
+        chunks = [
+            _make_chunk(file_path="a.py", embedding=_make_embedding()),
+            _make_chunk(file_path="b.py", embedding=_make_embedding()),
+        ]
+        await store.create_or_replace(chunks)
+        stats = await store.status()
+        assert stats["exists"] is True
+        assert stats["chunks"] == 2
+        assert stats["files"] == 2
+
+    @pytest.mark.asyncio()
+    async def test_create_empty_noop(self, tmp_path: Path) -> None:
+        store = IndexStore(tmp_path / "index")
+        await store.create_or_replace([])
+        assert not store.exists()
+
+    @pytest.mark.asyncio()
+    async def test_search_empty_store(self, tmp_path: Path) -> None:
+        store = IndexStore(tmp_path / "index")
+        results = await store.search(_make_embedding(), top_k=5)
+        assert results == []
+
+    @pytest.mark.asyncio()
+    async def test_replace_overwrites(self, tmp_path: Path) -> None:
+        store = IndexStore(tmp_path / "index")
+        emb = _make_embedding()
+        await store.create_or_replace([_make_chunk(file_path="old.py", embedding=emb)])
+        stats1 = await store.status()
+        assert stats1["chunks"] == 1
+
+        await store.create_or_replace(
+            [
+                _make_chunk(file_path="new1.py", embedding=emb),
+                _make_chunk(file_path="new2.py", embedding=emb),
+            ]
+        )
+        stats2 = await store.status()
+        assert stats2["chunks"] == 2


### PR DESCRIPTION
## Summary

- Implements `mita.index` package: Tree-sitter code parsing, Ollama embeddings (nomic-embed-text), LanceDB vector store, and RAG retrieval pipeline
- Adds CLI commands: `mita index build [--force]`, `mita index status`, `mita index search "<query>" [--top-k N]`, `mita index clear`
- Wires retriever into the agent loop for automatic RAG context injection during `mita chat`
- Respects `index.exclude_patterns` config, progress bars for indexing, embedding model pull prompt
- 46 new tests (272 total), all passing

## Test plan

- [x] `poetry run pytest` — 272 tests passing
- [x] `poetry run ruff check` — no lint errors
- [x] `poetry run ruff format --check` — all formatted
- [x] `poetry run mypy src/mita/index/` — no type errors
- [x] `mita index --help` — shows build/status/search/clear commands
- [ ] CI passes (lint + test matrix)

Closes #5

🤖 Generated with [Claude Code](https://claude.ai/code)