### PR TITLE
feat: Phase 6 — Skills System

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,14 @@
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+  jobs:
+    post_install:
+      - pip install poetry
+      - poetry config virtualenvs.create false
+      - poetry install --with docs --no-interaction
+
+mkdocs:
+  configuration: mkdocs.yml

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,51 @@
+# Installation
+
+## Requirements
+
+- Python 3.11+
+- [Ollama](https://ollama.com) installed and running
+
+## Install with pipx (recommended)
+
+```bash
+pipx install mita-code
+```
+
+## Install with pip
+
+```bash
+pip install mita-code
+```
+
+## Development Install
+
+```bash
+git clone https://github.com/jtdub/mita-code.git
+cd mita-code
+poetry install
+```
+
+## Verify Installation
+
+```bash
+mita --version
+```
+
+## Install Ollama
+
+Mita Code requires Ollama to be installed and running on your machine. Follow the instructions at [ollama.com](https://ollama.com) for your platform.
+
+Once installed, start the Ollama server:
+
+```bash
+ollama serve
+```
+
+Then pull a coding model:
+
+```bash
+mita models pull qwen2.5-coder:7b
+```
+
+!!! tip
+    Run `mita models recommend` to see which models fit your hardware best.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,63 @@
+# Quick Start
+
+## Interactive Chat
+
+Start an agentic chat session:
+
+```bash
+mita chat
+```
+
+Inside the session, type natural language prompts. The agent can read files, write code, run commands, and search your codebase.
+
+```
+mita> explain the auth module in this project
+mita> refactor the database connection to use async
+mita> /commit
+```
+
+### REPL Commands
+
+| Command | Action |
+|---|---|
+| `/quit`, `/exit`, `/q` | Exit the session |
+| `/clear` | Clear conversation history |
+| `/<skill>` | Invoke a skill (e.g., `/commit`, `/review`) |
+
+## Single-Shot Prompts
+
+For one-off questions without entering an interactive session:
+
+```bash
+mita ask "explain the auth module in this project"
+```
+
+Pipe input from other commands:
+
+```bash
+cat error.log | mita ask "what went wrong?"
+git diff | mita ask "review these changes"
+```
+
+## Model Management
+
+```bash
+# See what fits your hardware
+mita models recommend
+
+# List installed models
+mita models list
+
+# Pull a model
+mita models pull qwen2.5-coder:14b
+
+# Set as default
+mita models default qwen2.5-coder:14b
+```
+
+## Next Steps
+
+- [Memory System](../guide/memory.md) — Add persistent context with `MITA.md` files
+- [Codebase Indexing](../guide/indexing.md) — Enable RAG over your codebase
+- [Skills](../guide/skills.md) — Create reusable prompt templates
+- [Configuration](../guide/configuration.md) — Customize Mita to your workflow

--- a/docs/guide/chat.md
+++ b/docs/guide/chat.md
@@ -1,0 +1,44 @@
+# Chat & Ask
+
+## Interactive Chat
+
+```bash
+mita chat
+```
+
+Opens an interactive REPL with the agentic assistant. The agent has access to tools for reading/writing files, running shell commands, searching code, and more.
+
+### Tool Execution
+
+The agent can invoke tools automatically. Destructive actions (file writes, shell commands) require your confirmation before executing. Read-only tools like file reads, glob, and grep are auto-approved by default.
+
+Configure auto-approval in your config:
+
+```toml
+[tools]
+auto_approve = ["file_read", "glob", "grep"]
+confirm_destructive = true
+```
+
+### Streaming
+
+Responses stream token-by-token by default. Disable with:
+
+```toml
+[ui]
+stream = false
+```
+
+## Single-Shot Ask
+
+```bash
+mita ask "your prompt here"
+```
+
+Sends a single prompt and prints the response. Useful for scripting and piping:
+
+```bash
+cat error.log | mita ask "what went wrong?"
+git diff | mita ask "review these changes"
+mita ask "write a pytest for src/auth.py" > test_auth.py
+```

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1,0 +1,83 @@
+# Configuration
+
+Mita uses layered TOML configuration. Global settings cascade into project-level overrides.
+
+## Config Files
+
+| Scope | Location |
+|---|---|
+| Global | `~/.config/mita/config.toml` |
+| Project | `.mita/settings.toml` |
+
+Project settings override global settings.
+
+## View Configuration
+
+```bash
+mita config show    # Show merged configuration
+mita config path    # Show config file paths
+```
+
+## Full Schema
+
+```toml
+[ollama]
+host = "http://localhost:11434"
+timeout = 120
+
+[model]
+default = "qwen2.5-coder:7b"
+embedding = "nomic-embed-text"
+temperature = 0.1
+max_tokens = 4096
+context_window = 32768
+
+[tools]
+auto_approve = ["file_read", "glob", "grep"]
+confirm_destructive = true
+shell_timeout = 120
+banned_commands = ["rm -rf /", "mkfs", "dd if=/dev/zero"]
+
+[memory]
+max_lines_per_file = 200
+max_total_tokens = 4000
+
+[index]
+enabled = true
+chunk_size = 512
+chunk_overlap = 64
+top_k = 10
+exclude_patterns = [
+    "*.lock",
+    ".mita/**",
+    "node_modules/**",
+    ".git/**",
+    "*.min.js",
+    "*.min.css",
+    "dist/**",
+    "build/**",
+    "__pycache__/**",
+]
+
+[ui]
+theme = "auto"
+show_token_count = true
+stream = true
+markdown = true
+
+# Skills search paths
+skills_paths = ["~/.config/mita/skills", ".mita/skills"]
+
+# Hooks — lifecycle shell commands
+# [[hooks]]
+# event = "after_file_write"
+# command = "ruff format {file}"
+# match = "*.py"
+
+# MCP Plugins
+# [[plugins]]
+# name = "filesystem"
+# transport = "stdio"
+# command = "npx"
+# args = ["@modelcontextprotocol/server-filesystem", "."]
+```

--- a/docs/guide/indexing.md
+++ b/docs/guide/indexing.md
@@ -1,0 +1,72 @@
+# Codebase Indexing
+
+Mita can index your codebase for retrieval-augmented generation (RAG). When enabled, the agent automatically retrieves relevant code snippets to provide better, context-aware responses.
+
+## How It Works
+
+1. **Parse** — Tree-sitter extracts semantic chunks (functions, classes) from your code
+2. **Embed** — Ollama generates vector embeddings using `nomic-embed-text`
+3. **Store** — Chunks are stored in a local LanceDB database (`.mita/index/`)
+4. **Retrieve** — When you ask a question, relevant chunks are injected into the LLM context
+
+## Build the Index
+
+```bash
+mita index build
+```
+
+If the embedding model isn't installed, Mita will prompt you to pull it.
+
+Use `--force` to rebuild from scratch:
+
+```bash
+mita index build --force
+```
+
+## Search
+
+```bash
+mita index search "database connection pooling"
+mita index search "authentication" --top-k 5
+```
+
+## Status
+
+```bash
+mita index status
+```
+
+Shows chunk count, index size, and last build time.
+
+## Clear
+
+```bash
+mita index clear
+```
+
+Deletes the index. Rebuild with `mita index build`.
+
+## Configuration
+
+```toml
+[index]
+enabled = true
+chunk_size = 512
+chunk_overlap = 64
+top_k = 10
+exclude_patterns = [
+    "*.lock",
+    ".mita/**",
+    "node_modules/**",
+    ".git/**",
+    "*.min.js",
+    "*.min.css",
+    "dist/**",
+    "build/**",
+    "__pycache__/**",
+]
+```
+
+## Supported Languages
+
+Tree-sitter parsing supports semantic chunking for: Python, JavaScript, TypeScript, Rust, Go, Java, C, C++, Ruby, PHP, and more. Files in unsupported languages fall back to line-based chunking.

--- a/docs/guide/memory.md
+++ b/docs/guide/memory.md
@@ -1,0 +1,56 @@
+# Memory System
+
+Mita uses layered `MITA.md` files that are automatically discovered and injected into the LLM context. This gives the assistant persistent knowledge about your preferences, project conventions, and directory-specific context.
+
+## Memory Scopes
+
+| Scope | Location | Purpose |
+|---|---|---|
+| Global | `~/.config/mita/MITA.md` | Preferences across all projects |
+| Project | `<project_root>/MITA.md` | Project-specific conventions |
+| Directory | `<subdir>/MITA.md` | Directory-specific context |
+
+Higher-specificity files take priority. Each file is capped at 200 lines.
+
+## Commands
+
+### View Memory
+
+```bash
+mita memory show
+```
+
+Displays all discovered memory content that would be injected into the context.
+
+### Add Memory
+
+```bash
+mita memory add "Always use pytest for testing" --project
+mita memory add "Prefer async/await patterns" --global
+```
+
+### Edit Memory
+
+```bash
+mita memory edit              # Edit nearest MITA.md
+mita memory edit --global     # Edit global MITA.md
+mita memory edit --project    # Edit project MITA.md
+```
+
+Opens the file in `$EDITOR`.
+
+### Show Paths
+
+```bash
+mita memory path
+```
+
+Shows discovered memory file paths and whether they exist.
+
+## Configuration
+
+```toml
+[memory]
+max_lines_per_file = 200
+max_total_tokens = 4000
+```

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -1,0 +1,62 @@
+# Model Management
+
+Mita Code runs LLMs locally via Ollama. The `mita models` commands help you find, install, and manage models.
+
+## Recommendations
+
+```bash
+mita models recommend
+```
+
+Detects your hardware (RAM, VRAM, GPU) and recommends models that will run well on your machine.
+
+## List Installed Models
+
+```bash
+mita models list
+```
+
+## Pull a Model
+
+```bash
+mita models pull qwen2.5-coder:7b
+```
+
+## Set Default Model
+
+```bash
+mita models default qwen2.5-coder:14b
+```
+
+The default model is used for all chat and ask commands unless overridden.
+
+## Model Info
+
+```bash
+mita models info qwen2.5-coder:7b
+```
+
+## Remove a Model
+
+```bash
+mita models remove qwen2.5-coder:7b
+```
+
+## Hardware Info
+
+```bash
+mita models hardware
+```
+
+Shows detected RAM, VRAM, CPU, and GPU information.
+
+## Configuration
+
+```toml
+[model]
+default = "qwen2.5-coder:7b"
+embedding = "nomic-embed-text"
+temperature = 0.1
+max_tokens = 4096
+context_window = 32768
+```

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -1,0 +1,106 @@
+# Skills
+
+Skills are reusable, parameterized prompt templates stored as Markdown files. Use them to standardize common workflows like committing, code review, or explaining code.
+
+## Using Skills
+
+In the interactive REPL, type `/` followed by the skill name:
+
+```
+mita> /commit
+mita> /review
+mita> /explain src/auth.py
+```
+
+The skill template is rendered with your arguments and sent to the agent as a prompt.
+
+## Built-in Skills
+
+Mita ships with three built-in skills:
+
+| Skill | Description | Usage |
+|---|---|---|
+| `commit` | Generate a git commit message from staged changes | `/commit` |
+| `review` | Review code changes for bugs and improvements | `/review` or `/review src/auth.py` |
+| `explain` | Explain how code works | `/explain src/auth.py` |
+
+## Listing Skills
+
+```bash
+mita skills list
+```
+
+## Viewing Skill Details
+
+```bash
+mita skills show commit
+```
+
+## Creating Custom Skills
+
+```bash
+mita skills create my-skill
+```
+
+This creates a template file you can edit. Skill files are Markdown with YAML frontmatter:
+
+```markdown
+---
+name: my-skill
+description: "What this skill does"
+args:
+  - name: target
+    type: string
+    description: "The target file or symbol"
+    required: true
+  - name: format
+    type: string
+    description: "Output format"
+    required: false
+    default: "markdown"
+trigger: "^/my-skill$"
+---
+
+Analyze {{target}} and output in {{format}} format.
+
+Steps:
+1. Read the target file
+2. Perform analysis
+3. Output results
+```
+
+### Frontmatter Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Skill name (used for `/name` invocation) |
+| `description` | string | no | Human-readable description |
+| `args` | list | no | Accepted parameters |
+| `trigger` | regex | no | Regex pattern for matching invocations |
+
+### Argument Substitution
+
+Use `{{arg_name}}` placeholders in the template body. Arguments can be passed positionally or with `--name value` / `--name=value` syntax.
+
+If no args are declared, the entire user input after the skill name is available as `{{input}}`.
+
+## Skill Search Paths
+
+Skills are discovered from configured paths:
+
+```bash
+mita skills path
+```
+
+Default paths:
+
+- `~/.config/mita/skills/` — Global user skills
+- `.mita/skills/` — Project-local skills
+
+Earlier paths take priority when skills share the same name.
+
+## Configuration
+
+```toml
+skills_paths = ["~/.config/mita/skills", ".mita/skills"]
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,57 @@
+# Mita Code
+
+**Local-first, terminal-native agentic coding assistant powered by Ollama.**
+
+No API keys. No cloud. No telemetry. Your code never leaves your machine.
+
+---
+
+## What is Mita Code?
+
+Mita Code (`mita`) is a CLI coding assistant that runs large language models entirely on your hardware via [Ollama](https://ollama.com). It gives you an agentic tool loop — reading files, writing code, running shell commands, searching your codebase — all from the terminal, all locally.
+
+## Key Features
+
+<div class="grid cards" markdown>
+
+- :material-server-network: **100% Local** — All inference runs on your hardware via Ollama.
+- :material-tools: **Agentic Tool Loop** — Read/write files, run shell commands, git operations with confirmation for destructive actions.
+- :material-memory: **Layered Memory** — `MITA.md` files at global, project, and directory scope are automatically injected into context.
+- :material-magnify: **Codebase Indexing** — Local vector search (LanceDB + Tree-sitter) for RAG over your codebase.
+- :material-lightning-bolt: **Skills** — Reusable prompt templates stored as Markdown (e.g., `/commit`, `/review`).
+- :material-chip: **Hardware-Aware** — Detects your RAM, VRAM, and GPU to recommend models that run well on your machine.
+- :material-puzzle: **MCP Plugins** — Compatible with the [Model Context Protocol](https://modelcontextprotocol.io/) ecosystem.
+- :material-cog: **Layered Config** — TOML configuration cascades from global to project level.
+
+</div>
+
+## Quick Start
+
+```bash
+# Install
+pipx install mita-code
+
+# Start Ollama
+ollama serve
+
+# Pull a coding model
+mita models pull qwen2.5-coder:7b
+
+# Start an interactive session
+mita chat
+```
+
+See the [Installation](getting-started/installation.md) and [Quick Start](getting-started/quickstart.md) guides for details.
+
+## Tech Stack
+
+| Component | Library |
+|---|---|
+| CLI | [Typer](https://typer.tiangolo.com/) |
+| Terminal UI | [Rich](https://rich.readthedocs.io/) |
+| LLM Runtime | [Ollama](https://ollama.com) |
+| LLM Client | [LiteLLM](https://github.com/BerriAI/litellm) |
+| Vector Store | [LanceDB](https://lancedb.com/) |
+| Code Parsing | [Tree-sitter](https://tree-sitter.github.io/) |
+| Config | TOML (stdlib `tomllib`) |
+| Plugins | [MCP](https://modelcontextprotocol.io/) |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,0 +1,55 @@
+# CLI Commands
+
+## Top-Level
+
+| Command | Description |
+|---|---|
+| `mita chat` | Open an interactive chat session |
+| `mita ask <prompt>` | Send a single prompt (non-interactive) |
+| `mita --version` | Show version |
+
+## Config
+
+| Command | Description |
+|---|---|
+| `mita config show` | Show merged configuration |
+| `mita config path` | Show config file paths |
+
+## Memory
+
+| Command | Description |
+|---|---|
+| `mita memory show` | Show all discovered memory content |
+| `mita memory path` | Show memory file paths |
+| `mita memory edit [--global\|--project]` | Open MITA.md in `$EDITOR` |
+| `mita memory add <text> [--global\|--project]` | Append text to a MITA.md file |
+
+## Models
+
+| Command | Description |
+|---|---|
+| `mita models list` | List installed Ollama models |
+| `mita models pull <name>` | Pull a model from the registry |
+| `mita models remove <name>` | Remove an installed model |
+| `mita models recommend` | Recommend models for your hardware |
+| `mita models info <name>` | Show model details |
+| `mita models default <name>` | Set the default model |
+| `mita models hardware` | Show detected hardware info |
+
+## Index
+
+| Command | Description |
+|---|---|
+| `mita index build [--force]` | Build the codebase index |
+| `mita index status` | Show index statistics |
+| `mita index search <query> [--top-k N]` | Search the index |
+| `mita index clear` | Delete the index |
+
+## Skills
+
+| Command | Description |
+|---|---|
+| `mita skills list` | List available skills |
+| `mita skills show <name>` | Show skill details |
+| `mita skills create <name>` | Create a new skill from template |
+| `mita skills path` | Show skill search paths |

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -1,0 +1,89 @@
+# Configuration Schema
+
+Full reference for all configuration options in `config.toml` / `.mita/settings.toml`.
+
+## `[ollama]`
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `host` | string | `"http://localhost:11434"` | Ollama server URL |
+| `timeout` | int | `120` | Request timeout in seconds |
+
+## `[model]`
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `default` | string | `"qwen2.5-coder:7b"` | Default LLM for chat/ask |
+| `embedding` | string | `"nomic-embed-text"` | Embedding model for codebase indexing |
+| `temperature` | float | `0.1` | Sampling temperature |
+| `max_tokens` | int | `4096` | Maximum tokens per response |
+| `context_window` | int | `32768` | Context window size |
+
+## `[tools]`
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `auto_approve` | list[str] | `["file_read", "glob", "grep"]` | Tools that run without confirmation |
+| `confirm_destructive` | bool | `true` | Prompt before destructive actions |
+| `shell_timeout` | int | `120` | Shell command timeout in seconds |
+| `banned_commands` | list[str] | `["rm -rf /", ...]` | Commands that are always blocked |
+
+## `[memory]`
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `max_lines_per_file` | int | `200` | Max lines per MITA.md file |
+| `max_total_tokens` | int | `4000` | Max total tokens for all memory |
+
+## `[index]`
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | bool | `true` | Enable RAG indexing |
+| `chunk_size` | int | `512` | Lines per chunk |
+| `chunk_overlap` | int | `64` | Overlap between chunks |
+| `top_k` | int | `10` | Number of chunks to retrieve |
+| `exclude_patterns` | list[str] | See below | Glob patterns to exclude |
+
+Default exclude patterns:
+
+```toml
+exclude_patterns = [
+    "*.lock", ".mita/**", "node_modules/**", ".git/**",
+    "*.min.js", "*.min.css", "dist/**", "build/**", "__pycache__/**",
+]
+```
+
+## `[ui]`
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `theme` | string | `"auto"` | Color theme |
+| `show_token_count` | bool | `true` | Show token usage after responses |
+| `stream` | bool | `true` | Stream responses token-by-token |
+| `markdown` | bool | `true` | Render Markdown in responses |
+
+## `skills_paths`
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `skills_paths` | list[str] | `["~/.config/mita/skills", ".mita/skills"]` | Directories to search for skill files |
+
+## `[[hooks]]`
+
+| Key | Type | Required | Description |
+|---|---|---|---|
+| `event` | string | yes | Lifecycle event name |
+| `command` | string | yes | Shell command to run |
+| `match` | string | no | Glob pattern to filter (e.g., `"*.py"`) |
+
+## `[[plugins]]`
+
+| Key | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Plugin name |
+| `transport` | string | no | `"stdio"` or `"sse"` (default: `"stdio"`) |
+| `command` | string | no | Command to start the plugin |
+| `args` | list[str] | no | Arguments for the command |
+| `url` | string | no | URL for SSE transport |
+| `env` | dict | no | Environment variables |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,61 @@
+site_name: Mita Code
+site_description: Local-first, terminal-native agentic coding assistant powered by Ollama
+site_url: https://mita-code.readthedocs.io/
+repo_url: https://github.com/jtdub/mita-code
+repo_name: jtdub/mita-code
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - content.code.copy
+    - search.suggest
+    - search.highlight
+  icon:
+    repo: fontawesome/brands/github
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+  - tables
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Installation: getting-started/installation.md
+      - Quick Start: getting-started/quickstart.md
+  - User Guide:
+      - Chat & Ask: guide/chat.md
+      - Model Management: guide/models.md
+      - Memory System: guide/memory.md
+      - Codebase Indexing: guide/indexing.md
+      - Skills: guide/skills.md
+      - Configuration: guide/configuration.md
+  - Reference:
+      - CLI Commands: reference/cli.md
+      - Configuration Schema: reference/config.md

--- a/poetry.lock
+++ b/poetry.lock
@@ -3353,6 +3353,18 @@ files = [
 ]
 
 [[package]]
+name = "types-pyyaml"
+version = "6.0.12.20250915"
+description = "Typing stubs for PyYAML"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6"},
+    {file = "types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3"},
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
@@ -3588,4 +3600,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "deafef754b71d71e211232c7aefeb425cd41840124268c0b517474008b8166f5"
+content-hash = "f9cf04b2825dad72c71fda3164b036e3cb3ce5c02d578f6187c97faca290af22"

--- a/poetry.lock
+++ b/poetry.lock
@@ -238,12 +238,47 @@ files = [
 ]
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+description = "Internationalization utilities"
+optional = false
+python-versions = ">=3.8"
+groups = ["docs"]
+files = [
+    {file = "babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35"},
+    {file = "babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d"},
+]
+
+[package.extras]
+dev = ["backports.zoneinfo ; python_version < \"3.9\"", "freezegun (>=1.0,<2.0)", "jinja2 (>=3.0)", "pytest (>=6.0)", "pytest-cov", "pytz", "setuptools", "tzdata ; sys_platform == \"win32\""]
+
+[[package]]
+name = "backrefs"
+version = "6.2"
+description = "A wrapper around re and regex that adds additional back references."
+optional = false
+python-versions = ">=3.9"
+groups = ["docs"]
+files = [
+    {file = "backrefs-6.2-py310-none-any.whl", hash = "sha256:0fdc7b012420b6b144410342caeb8adc54c6866cf12064abc9bb211302e496f8"},
+    {file = "backrefs-6.2-py311-none-any.whl", hash = "sha256:08aa7fae530c6b2361d7bdcbda1a7c454e330cc9dbcd03f5c23205e430e5c3be"},
+    {file = "backrefs-6.2-py312-none-any.whl", hash = "sha256:c3f4b9cb2af8cda0d87ab4f57800b57b95428488477be164dd2b47be54db0c90"},
+    {file = "backrefs-6.2-py313-none-any.whl", hash = "sha256:12df81596ab511f783b7d87c043ce26bc5b0288cf3bb03610fe76b8189282b2b"},
+    {file = "backrefs-6.2-py314-none-any.whl", hash = "sha256:e5f805ae09819caa1aa0623b4a83790e7028604aa2b8c73ba602c4454e665de7"},
+    {file = "backrefs-6.2-py39-none-any.whl", hash = "sha256:664e33cd88c6840b7625b826ecf2555f32d491800900f5a541f772c485f7cda7"},
+    {file = "backrefs-6.2.tar.gz", hash = "sha256:f44ff4d48808b243b6c0cdc6231e22195c32f77046018141556c66f8bab72a49"},
+]
+
+[package.extras]
+extras = ["regex"]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["main", "docs"]
 files = [
     {file = "certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa"},
     {file = "certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7"},
@@ -255,7 +290,7 @@ version = "3.4.5"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["main", "docs"]
 files = [
     {file = "charset_normalizer-3.4.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:4167a621a9a1a986c73777dbc15d4b5eac8ac5c10393374109a343d4013ec765"},
     {file = "charset_normalizer-3.4.5-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f64c6bf8f32f9133b668c7f7a7cbdbc453412bc95ecdbd157f3b1e377a92990"},
@@ -378,7 +413,7 @@ version = "8.3.1"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["main", "docs"]
 files = [
     {file = "click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6"},
     {file = "click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a"},
@@ -393,7 +428,7 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["main", "dev"]
+groups = ["main", "dev", "docs"]
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
@@ -753,6 +788,24 @@ test-full = ["adlfs", "aiohttp (!=4.0.0a0,!=4.0.0a1)", "backports-zstd ; python_
 tqdm = ["tqdm"]
 
 [[package]]
+name = "ghp-import"
+version = "2.1.0"
+description = "Copy your docs directly to the gh-pages branch."
+optional = false
+python-versions = "*"
+groups = ["docs"]
+files = [
+    {file = "ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343"},
+    {file = "ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619"},
+]
+
+[package.dependencies]
+python-dateutil = ">=2.8.1"
+
+[package.extras]
+dev = ["flake8", "markdown", "twine", "wheel"]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
@@ -891,7 +944,7 @@ version = "3.11"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "docs"]
 files = [
     {file = "idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea"},
     {file = "idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"},
@@ -1019,7 +1072,7 @@ version = "3.1.6"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["main", "docs"]
 files = [
     {file = "jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"},
     {file = "jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"},
@@ -1388,6 +1441,22 @@ semantic-router = ["semantic-router (>=0.1.12) ; python_version >= \"3.9\" and p
 utils = ["numpydoc"]
 
 [[package]]
+name = "markdown"
+version = "3.10.2"
+description = "Python implementation of John Gruber's Markdown."
+optional = false
+python-versions = ">=3.10"
+groups = ["docs"]
+files = [
+    {file = "markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36"},
+    {file = "markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950"},
+]
+
+[package.extras]
+docs = ["mdx_gh_links (>=0.2)", "mkdocs (>=1.6)", "mkdocs-gen-files", "mkdocs-literate-nav", "mkdocs-nature (>=0.6)", "mkdocs-section-index", "mkdocstrings[python] (>=0.28.3)"]
+testing = ["coverage", "pyyaml"]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
@@ -1417,7 +1486,7 @@ version = "3.0.3"
 description = "Safely add untrusted strings to HTML/XML markup."
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "docs"]
 files = [
     {file = "markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559"},
     {file = "markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419"},
@@ -1532,6 +1601,108 @@ groups = ["main"]
 files = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
     {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
+]
+
+[[package]]
+name = "mergedeep"
+version = "1.3.4"
+description = "A deep merge function for 🐍."
+optional = false
+python-versions = ">=3.6"
+groups = ["docs"]
+files = [
+    {file = "mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307"},
+    {file = "mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8"},
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+description = "Project documentation with Markdown."
+optional = false
+python-versions = ">=3.8"
+groups = ["docs"]
+files = [
+    {file = "mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e"},
+    {file = "mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2"},
+]
+
+[package.dependencies]
+click = ">=7.0"
+colorama = {version = ">=0.4", markers = "platform_system == \"Windows\""}
+ghp-import = ">=1.0"
+jinja2 = ">=2.11.1"
+markdown = ">=3.3.6"
+markupsafe = ">=2.0.1"
+mergedeep = ">=1.3.4"
+mkdocs-get-deps = ">=0.2.0"
+packaging = ">=20.5"
+pathspec = ">=0.11.1"
+pyyaml = ">=5.1"
+pyyaml-env-tag = ">=0.1"
+watchdog = ">=2.0"
+
+[package.extras]
+i18n = ["babel (>=2.9.0)"]
+min-versions = ["babel (==2.9.0)", "click (==7.0)", "colorama (==0.4) ; platform_system == \"Windows\"", "ghp-import (==1.0)", "importlib-metadata (==4.4) ; python_version < \"3.10\"", "jinja2 (==2.11.1)", "markdown (==3.3.6)", "markupsafe (==2.0.1)", "mergedeep (==1.3.4)", "mkdocs-get-deps (==0.2.0)", "packaging (==20.5)", "pathspec (==0.11.1)", "pyyaml (==5.1)", "pyyaml-env-tag (==0.1)", "watchdog (==2.0)"]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.0"
+description = "MkDocs extension that lists all dependencies according to a mkdocs.yml file"
+optional = false
+python-versions = ">=3.8"
+groups = ["docs"]
+files = [
+    {file = "mkdocs_get_deps-0.2.0-py3-none-any.whl", hash = "sha256:2bf11d0b133e77a0dd036abeeb06dec8775e46efa526dc70667d8863eefc6134"},
+    {file = "mkdocs_get_deps-0.2.0.tar.gz", hash = "sha256:162b3d129c7fad9b19abfdcb9c1458a651628e4b1dea628ac68790fb3061c60c"},
+]
+
+[package.dependencies]
+mergedeep = ">=1.3.4"
+platformdirs = ">=2.2.0"
+pyyaml = ">=5.1"
+
+[[package]]
+name = "mkdocs-material"
+version = "9.7.4"
+description = "Documentation that simply works"
+optional = false
+python-versions = ">=3.8"
+groups = ["docs"]
+files = [
+    {file = "mkdocs_material-9.7.4-py3-none-any.whl", hash = "sha256:6549ad95e4d130ed5099759dfa76ea34c593eefdb9c18c97273605518e99cfbf"},
+    {file = "mkdocs_material-9.7.4.tar.gz", hash = "sha256:711b0ee63aca9a8c7124d4c73e83a25aa996e27e814767c3a3967df1b9e56f32"},
+]
+
+[package.dependencies]
+babel = ">=2.10"
+backrefs = ">=5.7.post1"
+colorama = ">=0.4"
+jinja2 = ">=3.1"
+markdown = ">=3.2"
+mkdocs = ">=1.6"
+mkdocs-material-extensions = ">=1.3"
+paginate = ">=0.5"
+pygments = ">=2.16"
+pymdown-extensions = ">=10.2"
+requests = ">=2.30"
+
+[package.extras]
+git = ["mkdocs-git-committers-plugin-2 (>=1.1)", "mkdocs-git-revision-date-localized-plugin (>=1.2.4)"]
+imaging = ["cairosvg (>=2.6)", "pillow (>=10.2)"]
+recommended = ["mkdocs-minify-plugin (>=0.7)", "mkdocs-redirects (>=1.2)", "mkdocs-rss-plugin (>=1.6)"]
+
+[[package]]
+name = "mkdocs-material-extensions"
+version = "1.3.1"
+description = "Extension pack for Python Markdown and MkDocs Material."
+optional = false
+python-versions = ">=3.8"
+groups = ["docs"]
+files = [
+    {file = "mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31"},
+    {file = "mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443"},
 ]
 
 [[package]]
@@ -1908,11 +2079,27 @@ version = "26.0"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main", "dev", "docs"]
 files = [
     {file = "packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529"},
     {file = "packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4"},
 ]
+
+[[package]]
+name = "paginate"
+version = "0.5.7"
+description = "Divides large result sets into pages for easier browsing"
+optional = false
+python-versions = "*"
+groups = ["docs"]
+files = [
+    {file = "paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591"},
+    {file = "paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945"},
+]
+
+[package.extras]
+dev = ["pytest", "tox"]
+lint = ["black"]
 
 [[package]]
 name = "pandas"
@@ -2012,7 +2199,7 @@ version = "1.0.4"
 description = "Utility library for gitignore style pattern matching of file paths."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["dev", "docs"]
 files = [
     {file = "pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723"},
     {file = "pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645"},
@@ -2030,7 +2217,7 @@ version = "4.9.4"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["dev", "docs"]
 files = [
     {file = "platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868"},
     {file = "platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934"},
@@ -2456,7 +2643,7 @@ version = "2.19.2"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main", "dev", "docs"]
 files = [
     {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
     {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
@@ -2492,6 +2679,25 @@ tomlkit = ">=0.10.1"
 [package.extras]
 spelling = ["pyenchant (>=3.2,<4.0)"]
 testutils = ["gitpython (>3)"]
+
+[[package]]
+name = "pymdown-extensions"
+version = "10.21"
+description = "Extension pack for Python Markdown."
+optional = false
+python-versions = ">=3.9"
+groups = ["docs"]
+files = [
+    {file = "pymdown_extensions-10.21-py3-none-any.whl", hash = "sha256:91b879f9f864d49794c2d9534372b10150e6141096c3908a455e45ca72ad9d3f"},
+    {file = "pymdown_extensions-10.21.tar.gz", hash = "sha256:39f4a020f40773f6b2ff31d2cd2546c2c04d0a6498c31d9c688d2be07e1767d5"},
+]
+
+[package.dependencies]
+markdown = ">=3.6"
+pyyaml = "*"
+
+[package.extras]
+extra = ["pygments (>=2.19.1)"]
 
 [[package]]
 name = "pytest"
@@ -2541,7 +2747,7 @@ version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-groups = ["main"]
+groups = ["main", "docs"]
 files = [
     {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
     {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
@@ -2571,7 +2777,7 @@ version = "6.0.3"
 description = "YAML parser and emitter for Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "docs"]
 files = [
     {file = "PyYAML-6.0.3-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:c2514fceb77bc5e7a2f7adfaa1feb2fb311607c9cb518dbc378688ec73d8292f"},
     {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c57bb8c96f6d1808c030b1687b9b5fb476abaa47f0db9c0101f5e9f394e97f4"},
@@ -2647,6 +2853,21 @@ files = [
     {file = "pyyaml-6.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:2e71d11abed7344e42a8849600193d15b6def118602c4c176f748e4583246007"},
     {file = "pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f"},
 ]
+
+[[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+description = "A custom YAML tag for referencing environment variables in YAML files."
+optional = false
+python-versions = ">=3.9"
+groups = ["docs"]
+files = [
+    {file = "pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04"},
+    {file = "pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff"},
+]
+
+[package.dependencies]
+pyyaml = "*"
 
 [[package]]
 name = "referencing"
@@ -2795,7 +3016,7 @@ version = "2.32.5"
 description = "Python HTTP for Humans."
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "docs"]
 files = [
     {file = "requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6"},
     {file = "requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"},
@@ -3001,7 +3222,7 @@ version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-groups = ["main"]
+groups = ["main", "docs"]
 files = [
     {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
     {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
@@ -3410,7 +3631,7 @@ version = "2.6.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "docs"]
 files = [
     {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
     {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
@@ -3421,6 +3642,49 @@ brotli = ["brotli (>=1.2.0) ; platform_python_implementation == \"CPython\"", "b
 h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+description = "Filesystem events monitoring"
+optional = false
+python-versions = ">=3.9"
+groups = ["docs"]
+files = [
+    {file = "watchdog-6.0.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d1cdb490583ebd691c012b3d6dae011000fe42edb7a82ece80965b42abd61f26"},
+    {file = "watchdog-6.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bc64ab3bdb6a04d69d4023b29422170b74681784ffb9463ed4870cf2f3e66112"},
+    {file = "watchdog-6.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c897ac1b55c5a1461e16dae288d22bb2e412ba9807df8397a635d88f671d36c3"},
+    {file = "watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c"},
+    {file = "watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2"},
+    {file = "watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c"},
+    {file = "watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948"},
+    {file = "watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860"},
+    {file = "watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0"},
+    {file = "watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c"},
+    {file = "watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134"},
+    {file = "watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b"},
+    {file = "watchdog-6.0.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:e6f0e77c9417e7cd62af82529b10563db3423625c5fce018430b249bf977f9e8"},
+    {file = "watchdog-6.0.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:90c8e78f3b94014f7aaae121e6b909674df5b46ec24d6bebc45c44c56729af2a"},
+    {file = "watchdog-6.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e7631a77ffb1f7d2eefa4445ebbee491c720a5661ddf6df3498ebecae5ed375c"},
+    {file = "watchdog-6.0.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:c7ac31a19f4545dd92fc25d200694098f42c9a8e391bc00bdd362c5736dbf881"},
+    {file = "watchdog-6.0.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:9513f27a1a582d9808cf21a07dae516f0fab1cf2d7683a742c498b93eedabb11"},
+    {file = "watchdog-6.0.0-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7a0e56874cfbc4b9b05c60c8a1926fedf56324bb08cfbc188969777940aef3aa"},
+    {file = "watchdog-6.0.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:e6439e374fc012255b4ec786ae3c4bc838cd7309a540e5fe0952d03687d8804e"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2"},
+    {file = "watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a"},
+    {file = "watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680"},
+    {file = "watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f"},
+    {file = "watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282"},
+]
+
+[package.extras]
+watchmedo = ["PyYAML (>=3.10)"]
 
 [[package]]
 name = "wcwidth"
@@ -3600,4 +3864,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "f9cf04b2825dad72c71fda3164b036e3cb3ce5c02d578f6187c97faca290af22"
+content-hash = "c9edaf7e7ff3969154708a4f4765c41c987c1011a8471f56e665b6ef933a9b47"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,11 @@ isort = ">=5.12.0"
 types-psutil = ">=5.9.0"
 types-pyyaml = "^6.0.12.20250915"
 
+
+[tool.poetry.group.docs.dependencies]
+mkdocs = "^1.6.1"
+mkdocs-material = "^9.7.4"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ lancedb = "0.25.3"
 tree-sitter = ">=0.23.0"
 tree-sitter-language-pack = ">=0.6.0"
 pandas = "^3.0.1"
+pyyaml = ">=6.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8.0.0"
@@ -51,6 +52,7 @@ pylint = ">=3.0.0"
 invoke = ">=2.0.0"
 isort = ">=5.12.0"
 types-psutil = ">=5.9.0"
+types-pyyaml = "^6.0.12.20250915"
 
 [build-system]
 requires = ["poetry-core"]

--- a/skills/commit.md
+++ b/skills/commit.md
@@ -1,0 +1,17 @@
+---
+name: commit
+description: "Generate a git commit message from staged changes"
+args: []
+trigger: "^/commit$"
+---
+
+Look at the current git diff (staged changes) and generate a clear, concise commit message.
+
+Steps:
+1. Run `git diff --cached` to see staged changes. If nothing is staged, run `git diff` to see unstaged changes.
+2. Analyze the changes and determine the type: feat, fix, refactor, docs, test, chore, etc.
+3. Write a commit message following conventional commit format:
+   - First line: `<type>: <short summary>` (max 72 chars)
+   - Blank line
+   - Optional body explaining the "why" (not the "what")
+4. Show the proposed commit message and ask for confirmation before committing.

--- a/skills/explain.md
+++ b/skills/explain.md
@@ -1,0 +1,20 @@
+---
+name: explain
+description: "Explain how code works"
+args:
+  - name: target
+    type: string
+    description: "File path or symbol to explain"
+    required: true
+---
+
+Explain how {{target}} works.
+
+Steps:
+1. Read the file or find the symbol in the codebase.
+2. Provide a clear explanation including:
+   - What the code does at a high level
+   - How the key parts work
+   - Important design decisions or patterns used
+   - How it connects to the rest of the codebase
+3. Use simple language. Include code references when helpful.

--- a/skills/review.md
+++ b/skills/review.md
@@ -1,0 +1,26 @@
+---
+name: review
+description: "Review code changes for bugs and improvements"
+args:
+  - name: target
+    type: string
+    description: "File path, git ref, or 'staged' to review"
+    required: false
+    default: "staged"
+---
+
+Review the code changes in {{target}} for potential issues.
+
+Steps:
+1. If target is "staged", run `git diff --cached`. Otherwise, read the specified file or diff.
+2. Look for:
+   - Bugs and logic errors
+   - Security vulnerabilities
+   - Missing error handling
+   - Performance concerns
+   - Code style issues
+3. Provide a structured review with:
+   - A summary of the changes
+   - Issues found (ranked by severity)
+   - Suggestions for improvement
+4. Be specific — reference file names and line numbers.

--- a/src/mita/cli.py
+++ b/src/mita/cli.py
@@ -263,6 +263,48 @@ def index_clear() -> None:
     asyncio.run(clear_index())
 
 
+# ── Skills commands ───────────────────────────────────────────────
+
+skills_app = typer.Typer(help="Skills management.")
+app.add_typer(skills_app, name="skills")
+
+
+@skills_app.command("list")
+def skills_list() -> None:
+    """List all available skills."""
+    from mita.skills.manager import list_skills
+
+    list_skills()
+
+
+@skills_app.command("show")
+def skills_show(
+    name: Annotated[str, typer.Argument(help="Skill name to show.")],
+) -> None:
+    """Show details about a skill."""
+    from mita.skills.manager import show_skill
+
+    show_skill(name)
+
+
+@skills_app.command("create")
+def skills_create(
+    name: Annotated[str, typer.Argument(help="Name for the new skill.")],
+) -> None:
+    """Create a new skill from a template."""
+    from mita.skills.manager import create_skill
+
+    create_skill(name)
+
+
+@skills_app.command("path")
+def skills_path() -> None:
+    """Show skill search paths."""
+    from mita.skills.manager import show_paths
+
+    show_paths()
+
+
 # ── Chat / Ask commands ───────────────────────────────────────────
 
 
@@ -289,7 +331,7 @@ def chat_command() -> None:
         nonlocal conversation
         conversation.clear_non_system()
 
-    asyncio.run(repl_loop(chat_console, on_input, on_clear=on_clear))
+    asyncio.run(repl_loop(chat_console, on_input, on_clear=on_clear, skills_paths=cfg.skills_paths))
 
 
 @app.command("ask")

--- a/src/mita/config/schema.py
+++ b/src/mita/config/schema.py
@@ -101,4 +101,6 @@ class MitaConfig(BaseModel):
     ui: UISettings = Field(default_factory=UISettings)
     hooks: list[HookDefinition] = Field(default_factory=list)
     plugins: list[PluginDefinition] = Field(default_factory=list)
-    skills_paths: list[str] = Field(default_factory=lambda: ["~/.config/mita/skills"])
+    skills_paths: list[str] = Field(
+        default_factory=lambda: ["~/.config/mita/skills", ".mita/skills"]
+    )

--- a/src/mita/skills/__init__.py
+++ b/src/mita/skills/__init__.py
@@ -1,0 +1,1 @@
+"""Skills system: reusable parameterized prompt templates."""

--- a/src/mita/skills/executor.py
+++ b/src/mita/skills/executor.py
@@ -1,0 +1,84 @@
+"""Render skill templates with argument substitution."""
+
+from __future__ import annotations
+
+import re
+
+from mita.skills.loader import Skill
+
+
+def render_skill(skill: Skill, user_input: str) -> str:
+    """Render a skill template, substituting arguments from user input.
+
+    Args:
+        skill: The skill to render.
+        user_input: The raw user input (e.g., "/commit -m 'fix bug'").
+
+    Returns:
+        The rendered prompt string.
+    """
+    args = _parse_args(user_input, skill)
+    return _substitute(skill.template, args)
+
+
+def _parse_args(user_input: str, skill: Skill) -> dict[str, str]:
+    """Parse arguments from user input into a dict."""
+    args: dict[str, str] = {}
+
+    # Remove the skill name prefix (e.g., "/commit" -> rest of input)
+    parts = user_input.strip().split(None, 1)
+    remainder = parts[1] if len(parts) > 1 else ""
+
+    # Map positional and named args
+    skill_args = skill.frontmatter.args
+    if not skill_args:
+        # No declared args — pass entire remainder as {{input}}
+        args["input"] = remainder
+        return args
+
+    # Simple approach: split remainder by spaces, assign positionally
+    # Also support --name=value and --name value
+    tokens = _tokenize(remainder)
+    positional_idx = 0
+
+    i = 0
+    while i < len(tokens):
+        token = tokens[i]
+        if token.startswith("--"):
+            # Named argument
+            key = token.lstrip("-")
+            if "=" in key:
+                k, v = key.split("=", 1)
+                args[k] = v
+            elif i + 1 < len(tokens):
+                args[key] = tokens[i + 1]
+                i += 1
+        elif positional_idx < len(skill_args):
+            args[skill_args[positional_idx].name] = token
+            positional_idx += 1
+        i += 1
+
+    # Fill defaults for missing args
+    for arg in skill_args:
+        if arg.name not in args and arg.default is not None:
+            args[arg.name] = str(arg.default)
+
+    return args
+
+
+def _tokenize(text: str) -> list[str]:
+    """Tokenize input, respecting quoted strings."""
+    tokens: list[str] = []
+    for match in re.finditer(r'"([^"]*)"' r"|'([^']*)'" r"|(\S+)", text):
+        tokens.append(match.group(1) or match.group(2) or match.group(3) or "")
+    return tokens
+
+
+def _substitute(template: str, args: dict[str, str]) -> str:
+    """Replace {{arg}} placeholders in the template."""
+
+    def replacer(match: re.Match[str]) -> str:
+        key = match.group(1).strip()
+        return args.get(key, match.group(0))
+
+    return re.sub(r"\{\{(\w+)\}\}", replacer, template)

--- a/src/mita/skills/loader.py
+++ b/src/mita/skills/loader.py
@@ -1,0 +1,117 @@
+"""Discover and parse skill Markdown files from configured paths."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field
+
+
+class SkillFrontmatter(BaseModel):
+    """YAML frontmatter for a skill file."""
+
+    name: str
+    description: str = ""
+    args: list[SkillArg] = Field(default_factory=list)
+    trigger: str | None = None
+
+
+class SkillArg(BaseModel):
+    """A parameter accepted by a skill."""
+
+    name: str
+    type: str = "string"
+    description: str = ""
+    required: bool = True
+    default: Any | None = None
+
+
+# Rebuild SkillFrontmatter to pick up SkillArg
+SkillFrontmatter.model_rebuild()
+
+
+class Skill(BaseModel):
+    """A parsed skill: frontmatter + Markdown template."""
+
+    frontmatter: SkillFrontmatter
+    template: str
+    source_path: Path
+
+
+def discover_skills(skills_paths: list[str]) -> list[Skill]:
+    """Discover and load all skills from the configured paths."""
+    skills: list[Skill] = []
+    seen_names: set[str] = set()
+
+    for raw_path in skills_paths:
+        path = Path(raw_path).expanduser()
+        if not path.is_dir():
+            continue
+        for md_file in sorted(path.glob("*.md")):
+            skill = parse_skill_file(md_file)
+            if skill and skill.frontmatter.name not in seen_names:
+                skills.append(skill)
+                seen_names.add(skill.frontmatter.name)
+
+    return skills
+
+
+def parse_skill_file(path: Path) -> Skill | None:
+    """Parse a single skill Markdown file."""
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    frontmatter, template = _split_frontmatter(content)
+    if frontmatter is None:
+        return None
+
+    try:
+        data = yaml.safe_load(frontmatter)
+    except yaml.YAMLError:
+        return None
+
+    if not isinstance(data, dict) or "name" not in data:
+        return None
+
+    try:
+        fm = SkillFrontmatter(**data)
+    except Exception:  # noqa: BLE001
+        return None
+
+    return Skill(frontmatter=fm, template=template.strip(), source_path=path)
+
+
+def find_skill(skills: list[Skill], name_or_trigger: str) -> Skill | None:
+    """Find a skill by name or trigger pattern."""
+    # Strip leading slash for matching
+    query = name_or_trigger.lstrip("/").split()[0] if name_or_trigger else ""
+
+    for skill in skills:
+        if skill.frontmatter.name == query:
+            return skill
+        if skill.frontmatter.trigger:
+            if re.search(skill.frontmatter.trigger, name_or_trigger):
+                return skill
+
+    return None
+
+
+def _split_frontmatter(content: str) -> tuple[str | None, str]:
+    """Split YAML frontmatter from Markdown body."""
+    content = content.strip()
+    if not content.startswith("---"):
+        return None, content
+
+    # Find the closing ---
+    end = content.find("---", 3)
+    if end == -1:
+        return None, content
+
+    frontmatter = content[3:end].strip()
+    body = content[end + 3 :].strip()
+    return frontmatter, body

--- a/src/mita/skills/manager.py
+++ b/src/mita/skills/manager.py
@@ -1,0 +1,129 @@
+"""CLI command handlers for skills management."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rich.console import Console
+from rich.markdown import Markdown
+from rich.table import Table
+
+from mita.config.loader import load_config
+from mita.skills.loader import discover_skills
+
+console = Console()
+
+SKILL_TEMPLATE = """---
+name: {name}
+description: "{description}"
+args: []
+---
+
+{name} skill prompt goes here.
+
+Use {{{{input}}}} to reference the user's input.
+"""
+
+
+def list_skills() -> None:
+    """List all available skills."""
+    config = load_config()
+    skills = discover_skills(config.skills_paths)
+
+    if not skills:
+        console.print("[yellow]No skills found.[/yellow]")
+        _show_paths(config.skills_paths)
+        return
+
+    table = Table(title="Available Skills")
+    table.add_column("Name", style="bold")
+    table.add_column("Description")
+    table.add_column("Args")
+    table.add_column("Source")
+
+    for skill in skills:
+        arg_names = ", ".join(a.name for a in skill.frontmatter.args) or "-"
+        table.add_row(
+            skill.frontmatter.name,
+            skill.frontmatter.description,
+            arg_names,
+            str(skill.source_path),
+        )
+
+    console.print(table)
+
+
+def show_skill(name: str) -> None:
+    """Show details and template for a skill."""
+    config = load_config()
+    skills = discover_skills(config.skills_paths)
+
+    match = None
+    for s in skills:
+        if s.frontmatter.name == name:
+            match = s
+            break
+
+    if not match:
+        console.print(f"[red]Skill '{name}' not found.[/red]")
+        return
+
+    console.print(f"[bold]Skill:[/bold] {match.frontmatter.name}")
+    console.print(f"[bold]Description:[/bold] {match.frontmatter.description}")
+    console.print(f"[bold]Source:[/bold] {match.source_path}")
+
+    if match.frontmatter.args:
+        console.print("[bold]Arguments:[/bold]")
+        for arg in match.frontmatter.args:
+            req = "required" if arg.required else f"optional, default={arg.default}"
+            console.print(f"  - {arg.name} ({arg.type}): {arg.description} [{req}]")
+
+    if match.frontmatter.trigger:
+        console.print(f"[bold]Trigger:[/bold] {match.frontmatter.trigger}")
+
+    console.print("\n[bold]Template:[/bold]")
+    console.print(Markdown(match.template))
+
+
+def create_skill(name: str) -> None:
+    """Create a new skill file from a template."""
+    config = load_config()
+
+    # Use the first writable path (prefer project-local)
+    target_dir = None
+    for raw_path in reversed(config.skills_paths):
+        p = Path(raw_path).expanduser()
+        target_dir = p
+        break
+
+    if target_dir is None:
+        console.print("[red]No skills path configured.[/red]")
+        return
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target_file = target_dir / f"{name}.md"
+
+    if target_file.exists():
+        console.print(f"[red]Skill '{name}' already exists at {target_file}.[/red]")
+        return
+
+    content = SKILL_TEMPLATE.format(name=name, description=f"A {name} skill.")
+    target_file.write_text(content, encoding="utf-8")
+    console.print(f"[green]Created skill '{name}' at {target_file}.[/green]")
+    console.print("Edit the file to customize the prompt template.")
+
+
+def show_paths() -> None:
+    """Show skill search paths."""
+    config = load_config()
+    _show_paths(config.skills_paths)
+
+
+def _show_paths(paths: list[str]) -> None:
+    """Display skill search paths."""
+    console.print("[bold]Skill search paths:[/bold]")
+    for raw_path in paths:
+        p = Path(raw_path).expanduser()
+        exists = p.is_dir()
+        style = "bold" if exists else "dim"
+        console.print(f"  {p}", style=style)

--- a/src/mita/ui/repl.py
+++ b/src/mita/ui/repl.py
@@ -11,11 +11,15 @@ from rich.console import Console
 
 from mita.ui.display import display_goodbye, display_welcome
 
+# Built-in REPL commands that should NOT be treated as skill invocations.
+_BUILTIN_COMMANDS = frozenset({"/quit", "/exit", "/q", "/clear"})
+
 
 async def repl_loop(
     console: Console,
     on_input: Callable[[str], Coroutine[Any, Any, None]],
     on_clear: Callable[[], None] | None = None,
+    skills_paths: list[str] | None = None,
 ) -> None:
     """Run the interactive REPL.
 
@@ -23,6 +27,7 @@ async def repl_loop(
         console: Rich console for output.
         on_input: Async callback called with each user input line.
         on_clear: Callback invoked when the user types /clear.
+        skills_paths: Skill search paths for ``/`` prefix invocation.
     """
     display_welcome(console)
 
@@ -49,4 +54,29 @@ async def repl_loop(
             console.print("[mita.dim]Conversation cleared.[/mita.dim]")
             continue
 
+        # Skill invocation: /name [args]
+        if user_input.startswith("/") and user_input.split()[0].lower() not in _BUILTIN_COMMANDS:
+            rendered = _try_render_skill(user_input, skills_paths or [], console)
+            if rendered is not None:
+                await on_input(rendered)
+                continue
+
         await on_input(user_input)
+
+
+def _try_render_skill(user_input: str, skills_paths: list[str], console: Console) -> str | None:
+    """Attempt to find and render a skill from user input.
+
+    Returns the rendered prompt string, or ``None`` if no matching skill was found.
+    """
+    from mita.skills.executor import render_skill
+    from mita.skills.loader import discover_skills, find_skill
+
+    skills = discover_skills(skills_paths)
+    skill = find_skill(skills, user_input)
+    if skill is None:
+        return None
+
+    rendered = render_skill(skill, user_input)
+    console.print(f"[dim]Running skill: {skill.frontmatter.name}[/dim]")
+    return rendered

--- a/tests/test_skills/test_executor.py
+++ b/tests/test_skills/test_executor.py
@@ -1,0 +1,133 @@
+"""Tests for mita.skills.executor."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from mita.skills.executor import _parse_args, _substitute, _tokenize, render_skill
+from mita.skills.loader import Skill, SkillArg, SkillFrontmatter
+
+
+def _make_skill(
+    name: str = "test",
+    args: list[SkillArg] | None = None,
+    template: str = "Do {{input}}.",
+) -> Skill:
+    return Skill(
+        frontmatter=SkillFrontmatter(
+            name=name,
+            description="test",
+            args=args or [],
+        ),
+        template=template,
+        source_path=Path("test.md"),
+    )
+
+
+class TestTokenize:
+    def test_simple(self) -> None:
+        assert _tokenize("foo bar baz") == ["foo", "bar", "baz"]
+
+    def test_double_quotes(self) -> None:
+        assert _tokenize('foo "bar baz"') == ["foo", "bar baz"]
+
+    def test_single_quotes(self) -> None:
+        assert _tokenize("foo 'bar baz'") == ["foo", "bar baz"]
+
+    def test_empty(self) -> None:
+        assert _tokenize("") == []
+
+    def test_mixed(self) -> None:
+        assert _tokenize("""hello "world test" 'foo bar'""") == [
+            "hello",
+            "world test",
+            "foo bar",
+        ]
+
+
+class TestSubstitute:
+    def test_basic(self) -> None:
+        assert _substitute("Hello {{name}}!", {"name": "world"}) == "Hello world!"
+
+    def test_missing_key(self) -> None:
+        assert _substitute("Hello {{name}}!", {}) == "Hello {{name}}!"
+
+    def test_multiple(self) -> None:
+        result = _substitute("{{a}} and {{b}}", {"a": "X", "b": "Y"})
+        assert result == "X and Y"
+
+
+class TestParseArgs:
+    def test_no_declared_args(self) -> None:
+        skill = _make_skill()
+        args = _parse_args("/test some input", skill)
+        assert args == {"input": "some input"}
+
+    def test_positional_arg(self) -> None:
+        skill = _make_skill(
+            args=[SkillArg(name="target", description="target")],
+            template="Explain {{target}}.",
+        )
+        args = _parse_args("/test src/main.py", skill)
+        assert args == {"target": "src/main.py"}
+
+    def test_named_arg(self) -> None:
+        skill = _make_skill(
+            args=[SkillArg(name="target", description="target")],
+            template="Explain {{target}}.",
+        )
+        args = _parse_args("/test --target=src/main.py", skill)
+        assert args == {"target": "src/main.py"}
+
+    def test_named_arg_space(self) -> None:
+        skill = _make_skill(
+            args=[SkillArg(name="target", description="target")],
+            template="Explain {{target}}.",
+        )
+        args = _parse_args("/test --target src/main.py", skill)
+        assert args == {"target": "src/main.py"}
+
+    def test_default_value(self) -> None:
+        skill = _make_skill(
+            args=[
+                SkillArg(
+                    name="target",
+                    description="target",
+                    required=False,
+                    default="staged",
+                ),
+            ],
+            template="Review {{target}}.",
+        )
+        args = _parse_args("/test", skill)
+        assert args == {"target": "staged"}
+
+    def test_no_input(self) -> None:
+        skill = _make_skill()
+        args = _parse_args("/test", skill)
+        assert args == {"input": ""}
+
+
+class TestRenderSkill:
+    def test_render_with_args(self) -> None:
+        skill = _make_skill(
+            args=[SkillArg(name="target", description="target")],
+            template="Explain {{target}} in detail.",
+        )
+        result = render_skill(skill, "/test src/main.py")
+        assert result == "Explain src/main.py in detail."
+
+    def test_render_no_args(self) -> None:
+        skill = _make_skill(template="Do {{input}}.")
+        result = render_skill(skill, "/test hello world")
+        assert result == "Do hello world."
+
+    def test_render_default_args(self) -> None:
+        skill = _make_skill(
+            args=[
+                SkillArg(name="target", required=False, default="staged"),
+            ],
+            template="Review {{target}}.",
+        )
+        result = render_skill(skill, "/test")
+        assert result == "Review staged."

--- a/tests/test_skills/test_loader.py
+++ b/tests/test_skills/test_loader.py
@@ -1,0 +1,185 @@
+"""Tests for mita.skills.loader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from mita.skills.loader import (
+    Skill,
+    SkillArg,
+    SkillFrontmatter,
+    _split_frontmatter,
+    discover_skills,
+    find_skill,
+    parse_skill_file,
+)
+
+VALID_SKILL = """\
+---
+name: test-skill
+description: "A test skill"
+args:
+  - name: target
+    type: string
+    description: "The target"
+    required: true
+trigger: "^/test-skill$"
+---
+
+Do something with {{target}}.
+"""
+
+MINIMAL_SKILL = """\
+---
+name: minimal
+---
+
+Hello.
+"""
+
+NO_FRONTMATTER = "Just plain markdown."
+
+BAD_YAML = """\
+---
+name: [invalid
+---
+
+Body.
+"""
+
+
+class TestSplitFrontmatter:
+    def test_valid_frontmatter(self) -> None:
+        fm, body = _split_frontmatter(VALID_SKILL)
+        assert fm is not None
+        assert "name: test-skill" in fm
+        assert "Do something" in body
+
+    def test_no_frontmatter(self) -> None:
+        fm, body = _split_frontmatter(NO_FRONTMATTER)
+        assert fm is None
+        assert body == NO_FRONTMATTER
+
+    def test_minimal(self) -> None:
+        fm, body = _split_frontmatter(MINIMAL_SKILL)
+        assert fm is not None
+        assert "name: minimal" in fm
+        assert body == "Hello."
+
+
+class TestParseSkillFile:
+    def test_valid(self, tmp_path: Path) -> None:
+        p = tmp_path / "test.md"
+        p.write_text(VALID_SKILL)
+        skill = parse_skill_file(p)
+        assert skill is not None
+        assert skill.frontmatter.name == "test-skill"
+        assert skill.frontmatter.description == "A test skill"
+        assert len(skill.frontmatter.args) == 1
+        assert skill.frontmatter.args[0].name == "target"
+        assert skill.frontmatter.trigger == "^/test-skill$"
+        assert "{{target}}" in skill.template
+
+    def test_minimal(self, tmp_path: Path) -> None:
+        p = tmp_path / "minimal.md"
+        p.write_text(MINIMAL_SKILL)
+        skill = parse_skill_file(p)
+        assert skill is not None
+        assert skill.frontmatter.name == "minimal"
+        assert skill.frontmatter.args == []
+
+    def test_no_frontmatter(self, tmp_path: Path) -> None:
+        p = tmp_path / "plain.md"
+        p.write_text(NO_FRONTMATTER)
+        assert parse_skill_file(p) is None
+
+    def test_bad_yaml(self, tmp_path: Path) -> None:
+        p = tmp_path / "bad.md"
+        p.write_text(BAD_YAML)
+        assert parse_skill_file(p) is None
+
+    def test_missing_name(self, tmp_path: Path) -> None:
+        p = tmp_path / "noname.md"
+        p.write_text("---\ndescription: no name\n---\nBody.")
+        assert parse_skill_file(p) is None
+
+    def test_nonexistent_file(self) -> None:
+        assert parse_skill_file(Path("/nonexistent/skill.md")) is None
+
+
+class TestDiscoverSkills:
+    def test_discovers_skills(self, tmp_path: Path) -> None:
+        (tmp_path / "a.md").write_text(VALID_SKILL)
+        (tmp_path / "b.md").write_text(MINIMAL_SKILL)
+        skills = discover_skills([str(tmp_path)])
+        names = {s.frontmatter.name for s in skills}
+        assert names == {"test-skill", "minimal"}
+
+    def test_deduplicates_by_name(self, tmp_path: Path) -> None:
+        d1 = tmp_path / "dir1"
+        d2 = tmp_path / "dir2"
+        d1.mkdir()
+        d2.mkdir()
+        (d1 / "skill.md").write_text(VALID_SKILL)
+        (d2 / "skill.md").write_text(VALID_SKILL)
+        skills = discover_skills([str(d1), str(d2)])
+        assert len(skills) == 1
+
+    def test_skips_missing_dirs(self) -> None:
+        skills = discover_skills(["/nonexistent/path"])
+        assert skills == []
+
+    def test_skips_non_md_files(self, tmp_path: Path) -> None:
+        (tmp_path / "readme.txt").write_text("not a skill")
+        skills = discover_skills([str(tmp_path)])
+        assert skills == []
+
+
+class TestFindSkill:
+    def _make_skills(self) -> list[Skill]:
+        return [
+            Skill(
+                frontmatter=SkillFrontmatter(
+                    name="commit",
+                    description="Commit skill",
+                    trigger="^/commit$",
+                ),
+                template="Commit template",
+                source_path=Path("commit.md"),
+            ),
+            Skill(
+                frontmatter=SkillFrontmatter(
+                    name="explain",
+                    description="Explain skill",
+                    args=[SkillArg(name="target", description="what to explain")],
+                ),
+                template="Explain {{target}}",
+                source_path=Path("explain.md"),
+            ),
+        ]
+
+    def test_find_by_name(self) -> None:
+        skills = self._make_skills()
+        result = find_skill(skills, "/commit")
+        assert result is not None
+        assert result.frontmatter.name == "commit"
+
+    def test_find_by_trigger(self) -> None:
+        skills = self._make_skills()
+        result = find_skill(skills, "/commit")
+        assert result is not None
+        assert result.frontmatter.name == "commit"
+
+    def test_find_with_args(self) -> None:
+        skills = self._make_skills()
+        result = find_skill(skills, "/explain src/main.py")
+        assert result is not None
+        assert result.frontmatter.name == "explain"
+
+    def test_not_found(self) -> None:
+        skills = self._make_skills()
+        assert find_skill(skills, "/nonexistent") is None
+
+    def test_empty_input(self) -> None:
+        skills = self._make_skills()
+        assert find_skill(skills, "") is None

--- a/tests/test_skills/test_manager.py
+++ b/tests/test_skills/test_manager.py
@@ -1,0 +1,78 @@
+"""Tests for mita.skills.manager."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from mita.skills.manager import create_skill, list_skills, show_paths, show_skill
+
+VALID_SKILL = """\
+---
+name: demo
+description: "A demo skill"
+args: []
+---
+
+Demo prompt.
+"""
+
+
+def _write_skill(tmp_path: Path) -> Path:
+    d = tmp_path / "skills"
+    d.mkdir()
+    (d / "demo.md").write_text(VALID_SKILL)
+    return d
+
+
+class TestListSkills:
+    def test_lists_skills(self, tmp_path: Path, capsys: object) -> None:
+        d = _write_skill(tmp_path)
+        with patch("mita.skills.manager.load_config") as mock_cfg:
+            mock_cfg.return_value.skills_paths = [str(d)]
+            list_skills()
+
+    def test_no_skills(self, tmp_path: Path) -> None:
+        with patch("mita.skills.manager.load_config") as mock_cfg:
+            mock_cfg.return_value.skills_paths = [str(tmp_path / "empty")]
+            list_skills()
+
+
+class TestShowSkill:
+    def test_found(self, tmp_path: Path) -> None:
+        d = _write_skill(tmp_path)
+        with patch("mita.skills.manager.load_config") as mock_cfg:
+            mock_cfg.return_value.skills_paths = [str(d)]
+            show_skill("demo")
+
+    def test_not_found(self, tmp_path: Path) -> None:
+        d = _write_skill(tmp_path)
+        with patch("mita.skills.manager.load_config") as mock_cfg:
+            mock_cfg.return_value.skills_paths = [str(d)]
+            show_skill("nonexistent")
+
+
+class TestCreateSkill:
+    def test_creates_file(self, tmp_path: Path) -> None:
+        target = tmp_path / "skills"
+        with patch("mita.skills.manager.load_config") as mock_cfg:
+            mock_cfg.return_value.skills_paths = [str(target)]
+            create_skill("new-skill")
+        assert (target / "new-skill.md").exists()
+        content = (target / "new-skill.md").read_text()
+        assert "name: new-skill" in content
+
+    def test_no_overwrite(self, tmp_path: Path) -> None:
+        d = _write_skill(tmp_path)
+        with patch("mita.skills.manager.load_config") as mock_cfg:
+            mock_cfg.return_value.skills_paths = [str(d)]
+            create_skill("demo")  # Already exists
+        # File should still have original content
+        assert "A demo skill" in (d / "demo.md").read_text()
+
+
+class TestShowPaths:
+    def test_shows_paths(self, tmp_path: Path) -> None:
+        with patch("mita.skills.manager.load_config") as mock_cfg:
+            mock_cfg.return_value.skills_paths = [str(tmp_path)]
+            show_paths()


### PR DESCRIPTION
## Summary
- Implement reusable prompt templates as Markdown files with YAML frontmatter and `{{arg}}` placeholder substitution
- Add `mita skills` CLI sub-commands: `list`, `show`, `create`, `path`
- Wire `/` prefix skill invocation in the REPL (e.g., `/commit` expands the commit skill template)
- Ship 3 built-in skills: `commit.md`, `review.md`, `explain.md`
- Default skills paths: `~/.config/mita/skills` (global) and `.mita/skills` (project-local)
- 42 unit tests covering loader, executor, and manager modules

## Test plan
- [x] `poetry run pytest tests/test_skills/ -v` — 42 tests pass
- [x] `poetry run ruff check` — no lint errors
- [x] `poetry run mypy` — no type errors
- [ ] CI passes on GitHub Actions

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)