### PR TITLE
feat: implement Phase 7 MCP plugin system

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,6 +9,7 @@ build:
       - pip install poetry
       - poetry config virtualenvs.create false
       - poetry install --with docs --no-interaction
+      - pip install mkdocs-material
 
 mkdocs:
   configuration: mkdocs.yml

--- a/poetry.lock
+++ b/poetry.lock
@@ -285,6 +285,104 @@ files = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.0.0"
+description = "Foreign Function Interface for Python calling C code."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "platform_python_implementation != \"PyPy\""
+files = [
+    {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
+    {file = "cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453"},
+    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495"},
+    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5"},
+    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb"},
+    {file = "cffi-2.0.0-cp310-cp310-win32.whl", hash = "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a"},
+    {file = "cffi-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739"},
+    {file = "cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe"},
+    {file = "cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26"},
+    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9"},
+    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414"},
+    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743"},
+    {file = "cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5"},
+    {file = "cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5"},
+    {file = "cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d"},
+    {file = "cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d"},
+    {file = "cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba"},
+    {file = "cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94"},
+    {file = "cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187"},
+    {file = "cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18"},
+    {file = "cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5"},
+    {file = "cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6"},
+    {file = "cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb"},
+    {file = "cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26"},
+    {file = "cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c"},
+    {file = "cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b"},
+    {file = "cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27"},
+    {file = "cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75"},
+    {file = "cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91"},
+    {file = "cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5"},
+    {file = "cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775"},
+    {file = "cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205"},
+    {file = "cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1"},
+    {file = "cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f"},
+    {file = "cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25"},
+    {file = "cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad"},
+    {file = "cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9"},
+    {file = "cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592"},
+    {file = "cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512"},
+    {file = "cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4"},
+    {file = "cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e"},
+    {file = "cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6"},
+    {file = "cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9"},
+    {file = "cffi-2.0.0-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:fe562eb1a64e67dd297ccc4f5addea2501664954f2692b69a76449ec7913ecbf"},
+    {file = "cffi-2.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:de8dad4425a6ca6e4e5e297b27b5c824ecc7581910bf9aee86cb6835e6812aa7"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:4647afc2f90d1ddd33441e5b0e85b16b12ddec4fca55f0d9671fef036ecca27c"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3f4d46d8b35698056ec29bca21546e1551a205058ae1a181d871e278b0b28165"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e6e73b9e02893c764e7e8d5bb5ce277f1a009cd5243f8228f75f842bf937c534"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:cb527a79772e5ef98fb1d700678fe031e353e765d1ca2d409c92263c6d43e09f"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:61d028e90346df14fedc3d1e5441df818d095f3b87d286825dfcbd6459b7ef63"},
+    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:0f6084a0ea23d05d20c3edcda20c3d006f9b6f3fefeac38f59262e10cef47ee2"},
+    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:1cd13c99ce269b3ed80b417dcd591415d3372bcac067009b6e0f59c7d4015e65"},
+    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:89472c9762729b5ae1ad974b777416bfda4ac5642423fa93bd57a09204712322"},
+    {file = "cffi-2.0.0-cp39-cp39-win32.whl", hash = "sha256:2081580ebb843f759b9f617314a24ed5738c51d2aee65d31e02f6f7a2b97707a"},
+    {file = "cffi-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9"},
+    {file = "cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529"},
+]
+
+[package.dependencies]
+pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.5"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
@@ -434,6 +532,78 @@ files = [
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
 markers = {main = "platform_system == \"Windows\"", dev = "sys_platform == \"win32\""}
+
+[[package]]
+name = "cryptography"
+version = "46.0.5"
+description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+optional = false
+python-versions = "!=3.9.0,!=3.9.1,>=3.8"
+groups = ["main"]
+files = [
+    {file = "cryptography-46.0.5-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:351695ada9ea9618b3500b490ad54c739860883df6c1f555e088eaf25b1bbaad"},
+    {file = "cryptography-46.0.5-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c18ff11e86df2e28854939acde2d003f7984f721eba450b56a200ad90eeb0e6b"},
+    {file = "cryptography-46.0.5-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d7e3d356b8cd4ea5aff04f129d5f66ebdc7b6f8eae802b93739ed520c47c79b"},
+    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:50bfb6925eff619c9c023b967d5b77a54e04256c4281b0e21336a130cd7fc263"},
+    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:803812e111e75d1aa73690d2facc295eaefd4439be1023fefc4995eaea2af90d"},
+    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ee190460e2fbe447175cda91b88b84ae8322a104fc27766ad09428754a618ed"},
+    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:f145bba11b878005c496e93e257c1e88f154d278d2638e6450d17e0f31e558d2"},
+    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e9251e3be159d1020c4030bd2e5f84d6a43fe54b6c19c12f51cde9542a2817b2"},
+    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:47fb8a66058b80e509c47118ef8a75d14c455e81ac369050f20ba0d23e77fee0"},
+    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4c3341037c136030cb46e4b1e17b7418ea4cbd9dd207e4a6f3b2b24e0d4ac731"},
+    {file = "cryptography-46.0.5-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:890bcb4abd5a2d3f852196437129eb3667d62630333aacc13dfd470fad3aaa82"},
+    {file = "cryptography-46.0.5-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80a8d7bfdf38f87ca30a5391c0c9ce4ed2926918e017c29ddf643d0ed2778ea1"},
+    {file = "cryptography-46.0.5-cp311-abi3-win32.whl", hash = "sha256:60ee7e19e95104d4c03871d7d7dfb3d22ef8a9b9c6778c94e1c8fcc8365afd48"},
+    {file = "cryptography-46.0.5-cp311-abi3-win_amd64.whl", hash = "sha256:38946c54b16c885c72c4f59846be9743d699eee2b69b6988e0a00a01f46a61a4"},
+    {file = "cryptography-46.0.5-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:94a76daa32eb78d61339aff7952ea819b1734b46f73646a07decb40e5b3448e2"},
+    {file = "cryptography-46.0.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5be7bf2fb40769e05739dd0046e7b26f9d4670badc7b032d6ce4db64dddc0678"},
+    {file = "cryptography-46.0.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe346b143ff9685e40192a4960938545c699054ba11d4f9029f94751e3f71d87"},
+    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c69fd885df7d089548a42d5ec05be26050ebcd2283d89b3d30676eb32ff87dee"},
+    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:8293f3dea7fc929ef7240796ba231413afa7b68ce38fd21da2995549f5961981"},
+    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:1abfdb89b41c3be0365328a410baa9df3ff8a9110fb75e7b52e66803ddabc9a9"},
+    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:d66e421495fdb797610a08f43b05269e0a5ea7f5e652a89bfd5a7d3c1dee3648"},
+    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:4e817a8920bfbcff8940ecfd60f23d01836408242b30f1a708d93198393a80b4"},
+    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:68f68d13f2e1cb95163fa3b4db4bf9a159a418f5f6e7242564fc75fcae667fd0"},
+    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a3d1fae9863299076f05cb8a778c467578262fae09f9dc0ee9b12eb4268ce663"},
+    {file = "cryptography-46.0.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4143987a42a2397f2fc3b4d7e3a7d313fbe684f67ff443999e803dd75a76826"},
+    {file = "cryptography-46.0.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7d731d4b107030987fd61a7f8ab512b25b53cef8f233a97379ede116f30eb67d"},
+    {file = "cryptography-46.0.5-cp314-cp314t-win32.whl", hash = "sha256:c3bcce8521d785d510b2aad26ae2c966092b7daa8f45dd8f44734a104dc0bc1a"},
+    {file = "cryptography-46.0.5-cp314-cp314t-win_amd64.whl", hash = "sha256:4d8ae8659ab18c65ced284993c2265910f6c9e650189d4e3f68445ef82a810e4"},
+    {file = "cryptography-46.0.5-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:4108d4c09fbbf2789d0c926eb4152ae1760d5a2d97612b92d508d96c861e4d31"},
+    {file = "cryptography-46.0.5-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1f30a86d2757199cb2d56e48cce14deddf1f9c95f1ef1b64ee91ea43fe2e18"},
+    {file = "cryptography-46.0.5-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:039917b0dc418bb9f6edce8a906572d69e74bd330b0b3fea4f79dab7f8ddd235"},
+    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ba2a27ff02f48193fc4daeadf8ad2590516fa3d0adeeb34336b96f7fa64c1e3a"},
+    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:61aa400dce22cb001a98014f647dc21cda08f7915ceb95df0c9eaf84b4b6af76"},
+    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ce58ba46e1bc2aac4f7d9290223cead56743fa6ab94a5d53292ffaac6a91614"},
+    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:420d0e909050490d04359e7fdb5ed7e667ca5c3c402b809ae2563d7e66a92229"},
+    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:582f5fcd2afa31622f317f80426a027f30dc792e9c80ffee87b993200ea115f1"},
+    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:bfd56bb4b37ed4f330b82402f6f435845a5f5648edf1ad497da51a8452d5d62d"},
+    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:a3d507bb6a513ca96ba84443226af944b0f7f47dcc9a399d110cd6146481d24c"},
+    {file = "cryptography-46.0.5-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9f16fbdf4da055efb21c22d81b89f155f02ba420558db21288b3d0035bafd5f4"},
+    {file = "cryptography-46.0.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ced80795227d70549a411a4ab66e8ce307899fad2220ce5ab2f296e687eacde9"},
+    {file = "cryptography-46.0.5-cp38-abi3-win32.whl", hash = "sha256:02f547fce831f5096c9a567fd41bc12ca8f11df260959ecc7c3202555cc47a72"},
+    {file = "cryptography-46.0.5-cp38-abi3-win_amd64.whl", hash = "sha256:556e106ee01aa13484ce9b0239bca667be5004efb0aabbed28d353df86445595"},
+    {file = "cryptography-46.0.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:3b4995dc971c9fb83c25aa44cf45f02ba86f71ee600d81091c2f0cbae116b06c"},
+    {file = "cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:bc84e875994c3b445871ea7181d424588171efec3e185dced958dad9e001950a"},
+    {file = "cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:2ae6971afd6246710480e3f15824ed3029a60fc16991db250034efd0b9fb4356"},
+    {file = "cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:d861ee9e76ace6cf36a6a89b959ec08e7bc2493ee39d07ffe5acb23ef46d27da"},
+    {file = "cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:2b7a67c9cd56372f3249b39699f2ad479f6991e62ea15800973b956f4b73e257"},
+    {file = "cryptography-46.0.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:8456928655f856c6e1533ff59d5be76578a7157224dbd9ce6872f25055ab9ab7"},
+    {file = "cryptography-46.0.5.tar.gz", hash = "sha256:abace499247268e3757271b2f1e244b36b06f8515cf27c4d49468fc9eb16e93d"},
+]
+
+[package.dependencies]
+cffi = {version = ">=2.0.0", markers = "python_full_version >= \"3.9.0\" and platform_python_implementation != \"PyPy\""}
+
+[package.extras]
+docs = ["sphinx (>=5.3.0)", "sphinx-inline-tabs", "sphinx-rtd-theme (>=3.0.0)"]
+docstest = ["pyenchant (>=3)", "readme-renderer (>=30.0)", "sphinxcontrib-spelling (>=7.3.1)"]
+nox = ["nox[uv] (>=2024.4.15)"]
+pep8test = ["check-sdist", "click (>=8.0.1)", "mypy (>=1.14)", "ruff (>=0.11.11)"]
+sdist = ["build (>=1.0.0)"]
+ssh = ["bcrypt (>=3.1.5)"]
+test = ["certifi (>=2024)", "cryptography-vectors (==46.0.5)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
+test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "deprecation"
@@ -902,6 +1072,18 @@ cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
 zstd = ["zstandard (>=0.18.0)"]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+description = "Consume Server-Sent Event (SSE) messages with HTTPX."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc"},
+    {file = "httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d"},
+]
 
 [[package]]
 name = "huggingface-hub"
@@ -1590,6 +1772,39 @@ files = [
     {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
     {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
 ]
+
+[[package]]
+name = "mcp"
+version = "1.26.0"
+description = "Model Context Protocol SDK"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca"},
+    {file = "mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66"},
+]
+
+[package.dependencies]
+anyio = ">=4.5"
+httpx = ">=0.27.1"
+httpx-sse = ">=0.4"
+jsonschema = ">=4.20.0"
+pydantic = ">=2.11.0,<3.0.0"
+pydantic-settings = ">=2.5.2"
+pyjwt = {version = ">=2.10.1", extras = ["crypto"]}
+python-multipart = ">=0.0.9"
+pywin32 = {version = ">=310", markers = "sys_platform == \"win32\""}
+sse-starlette = ">=1.6.1"
+starlette = ">=0.27"
+typing-extensions = ">=4.9.0"
+typing-inspection = ">=0.4.1"
+uvicorn = {version = ">=0.31.1", markers = "sys_platform != \"emscripten\""}
+
+[package.extras]
+cli = ["python-dotenv (>=1.0.0)", "typer (>=0.16.0)"]
+rich = ["rich (>=13.9.4)"]
+ws = ["websockets (>=15.0.1)"]
 
 [[package]]
 name = "mdurl"
@@ -2482,6 +2697,19 @@ files = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+description = "C parser in Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\""
+files = [
+    {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
+    {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 description = "Data validation using Python type hints"
@@ -2638,6 +2866,30 @@ files = [
 typing-extensions = ">=4.14.1"
 
 [[package]]
+name = "pydantic-settings"
+version = "2.13.1"
+description = "Settings management using Pydantic"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237"},
+    {file = "pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025"},
+]
+
+[package.dependencies]
+pydantic = ">=2.7.0"
+python-dotenv = ">=0.21.0"
+typing-inspection = ">=0.4.0"
+
+[package.extras]
+aws-secrets-manager = ["boto3 (>=1.35.0)", "boto3-stubs[secretsmanager]"]
+azure-key-vault = ["azure-identity (>=1.16.0)", "azure-keyvault-secrets (>=4.8.0)"]
+gcp-secret-manager = ["google-cloud-secret-manager (>=2.23.1)"]
+toml = ["tomli (>=2.0.1)"]
+yaml = ["pyyaml (>=6.0.1)"]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -2651,6 +2903,27 @@ files = [
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
+name = "pyjwt"
+version = "2.11.0"
+description = "JSON Web Token implementation in Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pyjwt-2.11.0-py3-none-any.whl", hash = "sha256:94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469"},
+    {file = "pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623"},
+]
+
+[package.dependencies]
+cryptography = {version = ">=3.4.0", optional = true, markers = "extra == \"crypto\""}
+
+[package.extras]
+crypto = ["cryptography (>=3.4.0)"]
+dev = ["coverage[toml] (==7.10.7)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=8.4.2,<9.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
+docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
+tests = ["coverage[toml] (==7.10.7)", "pytest (>=8.4.2,<9.0.0)"]
 
 [[package]]
 name = "pylint"
@@ -2770,6 +3043,49 @@ files = [
 
 [package.extras]
 cli = ["click (>=5.0)"]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.22"
+description = "A streaming multipart parser for Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155"},
+    {file = "python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58"},
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+description = "Python for Window Extensions"
+optional = false
+python-versions = "*"
+groups = ["main"]
+markers = "sys_platform == \"win32\""
+files = [
+    {file = "pywin32-311-cp310-cp310-win32.whl", hash = "sha256:d03ff496d2a0cd4a5893504789d4a15399133fe82517455e78bad62efbb7f0a3"},
+    {file = "pywin32-311-cp310-cp310-win_amd64.whl", hash = "sha256:797c2772017851984b97180b0bebe4b620bb86328e8a884bb626156295a63b3b"},
+    {file = "pywin32-311-cp310-cp310-win_arm64.whl", hash = "sha256:0502d1facf1fed4839a9a51ccbcc63d952cf318f78ffc00a7e78528ac27d7a2b"},
+    {file = "pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151"},
+    {file = "pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503"},
+    {file = "pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2"},
+    {file = "pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31"},
+    {file = "pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067"},
+    {file = "pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852"},
+    {file = "pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d"},
+    {file = "pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d"},
+    {file = "pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a"},
+    {file = "pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee"},
+    {file = "pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87"},
+    {file = "pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42"},
+    {file = "pywin32-311-cp38-cp38-win32.whl", hash = "sha256:6c6f2969607b5023b0d9ce2541f8d2cbb01c4f46bc87456017cf63b73f1e2d8c"},
+    {file = "pywin32-311-cp38-cp38-win_amd64.whl", hash = "sha256:c8015b09fb9a5e188f83b7b04de91ddca4658cee2ae6f3bc483f0b21a77ef6cd"},
+    {file = "pywin32-311-cp39-cp39-win32.whl", hash = "sha256:aba8f82d551a942cb20d4a83413ccbac30790b50efb89a75e4f586ac0bb8056b"},
+    {file = "pywin32-311-cp39-cp39-win_amd64.whl", hash = "sha256:e0c4cfb0621281fe40387df582097fd796e80430597cb9944f0ae70447bacd91"},
+    {file = "pywin32-311-cp39-cp39-win_arm64.whl", hash = "sha256:62ea666235135fee79bb154e695f3ff67370afefd71bd7fea7512fc70ef31e3d"},
+]
 
 [[package]]
 name = "pyyaml"
@@ -3241,6 +3557,47 @@ files = [
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "3.3.2"
+description = "SSE plugin for Starlette"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "sse_starlette-3.3.2-py3-none-any.whl", hash = "sha256:5c3ea3dad425c601236726af2f27689b74494643f57017cafcb6f8c9acfbb862"},
+    {file = "sse_starlette-3.3.2.tar.gz", hash = "sha256:678fca55a1945c734d8472a6cad186a55ab02840b4f6786f5ee8770970579dcd"},
+]
+
+[package.dependencies]
+anyio = ">=4.7.0"
+starlette = ">=0.49.1"
+
+[package.extras]
+daphne = ["daphne (>=4.2.0)"]
+examples = ["aiosqlite (>=0.21.0)", "fastapi (>=0.115.12)", "sqlalchemy[asyncio] (>=2.0.41)", "uvicorn (>=0.34.0)"]
+granian = ["granian (>=2.3.1)"]
+uvicorn = ["uvicorn (>=0.34.0)"]
+
+[[package]]
+name = "starlette"
+version = "0.52.1"
+description = "The little ASGI library that shines."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74"},
+    {file = "starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933"},
+]
+
+[package.dependencies]
+anyio = ">=3.6.2,<5"
+typing-extensions = {version = ">=4.10.0", markers = "python_version < \"3.13\""}
+
+[package.extras]
+full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
+
+[[package]]
 name = "tenacity"
 version = "9.1.4"
 description = "Retry code until it succeeds"
@@ -3644,6 +4001,26 @@ socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [[package]]
+name = "uvicorn"
+version = "0.41.0"
+description = "The lightning-fast ASGI server."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "sys_platform != \"emscripten\""
+files = [
+    {file = "uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187"},
+    {file = "uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a"},
+]
+
+[package.dependencies]
+click = ">=7.0"
+h11 = ">=0.8"
+
+[package.extras]
+standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.15.1) ; sys_platform != \"win32\" and sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\"", "watchfiles (>=0.20)", "websockets (>=10.4)"]
+
+[[package]]
 name = "watchdog"
 version = "6.0.0"
 description = "Filesystem events monitoring"
@@ -3864,4 +4241,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "c9edaf7e7ff3969154708a4f4765c41c987c1011a8471f56e665b6ef933a9b47"
+content-hash = "373403a0ea31844f0704069ba80dc3d3d2cb6f2a65b1a90a74d706e9041840c0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ tree-sitter = ">=0.23.0"
 tree-sitter-language-pack = ">=0.6.0"
 pandas = "^3.0.1"
 pyyaml = ">=6.0"
+mcp = ">=1.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8.0.0"

--- a/src/mita/agent/loop.py
+++ b/src/mita/agent/loop.py
@@ -55,6 +55,15 @@ async def run_agent(
     # Initialize
     if registry is None:
         registry = create_default_registry()
+
+    # Load MCP plugin tools (if configured and not already loaded)
+    if config.plugins and not any(d.source.startswith("mcp:") for d in registry.get_definitions()):
+        from mita.plugins.manager import PluginManager
+
+        plugin_mgr = PluginManager(config.plugins)
+        await plugin_mgr.start_all(console=console)
+        await plugin_mgr.register_tools_async(registry)
+
     if llm_client is None:
         llm_client = LLMClient(config)
     if conversation is None:

--- a/src/mita/cli.py
+++ b/src/mita/cli.py
@@ -362,12 +362,26 @@ def plugins_add(
         console.print("[red]Provide --command or --url.[/red]")
         raise typer.Exit(1)
 
-    from mita.config.defaults import get_project_config_path
+    from pathlib import Path
+
+    from mita.config.defaults import (
+        PROJECT_CONFIG_DIR,
+        PROJECT_CONFIG_FILE,
+        _find_project_root,
+        get_project_config_path,
+    )
 
     project_path = get_project_config_path()
     if not project_path:
-        console.print("[red]Not in a project directory (no .mita/).[/red]")
-        raise typer.Exit(1)
+        # Create .mita/settings.toml if we're in a project root (has .git)
+        root = _find_project_root(Path.cwd())
+        if root is None:
+            console.print("[red]Not in a project directory (no .git or .mita/).[/red]")
+            raise typer.Exit(1)
+        config_dir = root / PROJECT_CONFIG_DIR
+        config_dir.mkdir(exist_ok=True)
+        project_path = config_dir / PROJECT_CONFIG_FILE
+        project_path.touch()
 
     transport = "stdio" if command else "sse"
     # Build TOML block

--- a/src/mita/cli.py
+++ b/src/mita/cli.py
@@ -305,6 +305,157 @@ def skills_path() -> None:
     show_paths()
 
 
+# ── Plugin commands ───────────────────────────────────────────────
+
+plugins_app = typer.Typer(help="MCP plugin management.")
+app.add_typer(plugins_app, name="plugins")
+
+
+@plugins_app.command("list")
+def plugins_list() -> None:
+    """List configured plugins and their tools."""
+    import asyncio
+
+    from mita.plugins.manager import PluginManager
+
+    cfg = load_config()
+    if not cfg.plugins:
+        console.print("[dim]No plugins configured.[/dim]")
+        return
+
+    async def _list() -> None:
+        mgr = PluginManager(cfg.plugins)
+        started = await mgr.start_all(console=console)
+        try:
+            for plugin in cfg.plugins:
+                connected = plugin.name in started
+                status = "[green]connected[/green]" if connected else "[red]not connected[/red]"
+                transport = plugin.transport
+                target = plugin.command or plugin.url or ""
+                console.print(f"  {plugin.name} ({transport}) — {status}")
+                console.print(f"    {target}")
+
+                if connected:
+                    tools_map = await mgr.list_tools(plugin.name)
+                    tools = tools_map.get(plugin.name, [])
+                    if tools:
+                        for t in tools:
+                            console.print(f"    - {t['name']}: {t['description']}")
+                    else:
+                        console.print("    [dim]No tools[/dim]")
+        finally:
+            await mgr.stop_all()
+
+    asyncio.run(_list())
+
+
+@plugins_app.command("add")
+def plugins_add(
+    name: Annotated[str, typer.Argument(help="Plugin name.")],
+    command: Annotated[
+        str | None, typer.Option("--command", "-c", help="Command for stdio.")
+    ] = None,
+    url: Annotated[str | None, typer.Option("--url", "-u", help="URL for SSE.")] = None,
+) -> None:
+    """Add an MCP plugin to project config."""
+    if not command and not url:
+        console.print("[red]Provide --command or --url.[/red]")
+        raise typer.Exit(1)
+
+    from mita.config.defaults import get_project_config_path
+
+    project_path = get_project_config_path()
+    if not project_path:
+        console.print("[red]Not in a project directory (no .mita/).[/red]")
+        raise typer.Exit(1)
+
+    transport = "stdio" if command else "sse"
+    # Build TOML block
+    lines = [f'\n[[plugins]]\nname = "{name}"\ntransport = "{transport}"']
+    if command:
+        # Split command into executable + args
+        parts = command.split()
+        lines.append(f'command = "{parts[0]}"')
+        if len(parts) > 1:
+            args_toml = ", ".join(f'"{a}"' for a in parts[1:])
+            lines.append(f"args = [{args_toml}]")
+    if url:
+        lines.append(f'url = "{url}"')
+
+    block = "\n".join(lines) + "\n"
+
+    with open(project_path, "a") as f:
+        f.write(block)
+
+    console.print(f"[green]Plugin '{name}' added to {project_path}[/green]")
+
+
+@plugins_app.command("remove")
+def plugins_remove(
+    name: Annotated[str, typer.Argument(help="Plugin name to remove.")],
+) -> None:
+    """Remove an MCP plugin from project config."""
+    from mita.config.defaults import get_project_config_path
+
+    project_path = get_project_config_path()
+    if not project_path or not project_path.is_file():
+        console.print("[red]No project config found.[/red]")
+        raise typer.Exit(1)
+
+    import tomllib
+
+    with open(project_path, "rb") as f:
+        data = tomllib.load(f)
+
+    plugins = data.get("plugins", [])
+    new_plugins = [p for p in plugins if p.get("name") != name]
+    if len(new_plugins) == len(plugins):
+        console.print(f"[yellow]Plugin '{name}' not found in project config.[/yellow]")
+        return
+
+    data["plugins"] = new_plugins
+    _write_toml(project_path, data)
+    console.print(f"[green]Plugin '{name}' removed.[/green]")
+
+
+@plugins_app.command("test")
+def plugins_test(
+    name: Annotated[str, typer.Argument(help="Plugin name to test.")],
+) -> None:
+    """Test connectivity to an MCP plugin."""
+    import asyncio
+
+    from mita.plugins.manager import PluginManager
+
+    cfg = load_config()
+    plugin = next((p for p in cfg.plugins if p.name == name), None)
+    if not plugin:
+        console.print(f"[red]Plugin '{name}' not found in configuration.[/red]")
+        raise typer.Exit(1)
+
+    async def _test() -> None:
+        mgr = PluginManager([plugin])
+        started = await mgr.start_all(console=console)
+        try:
+            if name not in started:
+                console.print(f"[red]Failed to connect to '{name}'.[/red]")
+                raise typer.Exit(1)
+
+            result = await mgr.test_plugin(name)
+            if result.get("ping"):
+                console.print(f"[green]Plugin '{name}' is healthy.[/green]")
+                tool_names = result.get("tool_names", [])
+                console.print(f"  Tools: {len(tool_names)}")
+                for t in tool_names:
+                    console.print(f"    - {t}")
+            else:
+                console.print(f"[red]Plugin '{name}' ping failed.[/red]")
+        finally:
+            await mgr.stop_all()
+
+    asyncio.run(_test())
+
+
 # ── Ollama server commands ────────────────────────────────────────
 
 ollama_app = typer.Typer(help="Ollama server management.")
@@ -479,3 +630,12 @@ def _toml_value(v: object) -> str:
         items = ", ".join(_toml_value(i) for i in v)
         return f"[{items}]"
     return repr(v)
+
+
+def _write_toml(path: object, data: dict) -> None:  # type: ignore[type-arg]
+    """Write a dict back to a TOML file."""
+    from pathlib import Path
+
+    lines: list[str] = []
+    _dict_to_toml(data, lines, prefix="")
+    Path(str(path)).write_text("\n".join(lines) + "\n")

--- a/src/mita/plugins/__init__.py
+++ b/src/mita/plugins/__init__.py
@@ -1,0 +1,1 @@
+"""MCP plugin system — discover and call tools from MCP servers."""

--- a/src/mita/plugins/client.py
+++ b/src/mita/plugins/client.py
@@ -1,0 +1,152 @@
+"""MCP client wrapper for a single plugin server."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from contextlib import AsyncExitStack
+from typing import Any
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+from mita.config.schema import PluginDefinition
+
+
+class MCPPluginClient:
+    """Manages connection to a single MCP server."""
+
+    def __init__(self, plugin: PluginDefinition) -> None:
+        self._plugin = plugin
+        self._session: ClientSession | None = None
+        self._exit_stack: AsyncExitStack | None = None
+
+    @property
+    def name(self) -> str:
+        return self._plugin.name
+
+    @property
+    def transport(self) -> str:
+        return self._plugin.transport
+
+    @property
+    def connected(self) -> bool:
+        return self._session is not None
+
+    async def connect(self, timeout: float = 30.0) -> None:
+        """Connect to the MCP server and initialize the session."""
+        if self._session is not None:
+            return
+
+        self._exit_stack = AsyncExitStack()
+
+        if self._plugin.transport == "stdio":
+            await self._connect_stdio(timeout)
+        elif self._plugin.transport == "sse":
+            await self._connect_sse(timeout)
+        else:
+            raise ValueError(f"Unsupported transport: {self._plugin.transport}")
+
+    async def _connect_stdio(self, timeout: float) -> None:
+        """Connect via stdio transport (subprocess)."""
+        assert self._exit_stack is not None
+
+        if not self._plugin.command:
+            raise ValueError(f"Plugin '{self.name}' requires a command for stdio transport")
+
+        # Build environment: inherit current env, overlay plugin-specific vars
+        env: dict[str, str] = {**os.environ, **self._plugin.env}
+
+        server_params = StdioServerParameters(
+            command=self._plugin.command,
+            args=self._plugin.args,
+            env=env,
+        )
+
+        transport = await self._exit_stack.enter_async_context(stdio_client(server_params))
+        read_stream, write_stream = transport
+
+        session = await self._exit_stack.enter_async_context(
+            ClientSession(read_stream, write_stream)
+        )
+        await asyncio.wait_for(session.initialize(), timeout=timeout)
+        self._session = session
+
+    async def _connect_sse(self, timeout: float) -> None:
+        """Connect via SSE transport (HTTP)."""
+        assert self._exit_stack is not None
+
+        if not self._plugin.url:
+            raise ValueError(f"Plugin '{self.name}' requires a url for SSE transport")
+
+        from mcp.client.sse import sse_client
+
+        transport = await self._exit_stack.enter_async_context(sse_client(self._plugin.url))
+        read_stream, write_stream = transport
+
+        session = await self._exit_stack.enter_async_context(
+            ClientSession(read_stream, write_stream)
+        )
+        await asyncio.wait_for(session.initialize(), timeout=timeout)
+        self._session = session
+
+    async def disconnect(self) -> None:
+        """Disconnect from the MCP server and clean up resources."""
+        if self._exit_stack is not None:
+            await self._exit_stack.aclose()
+            self._exit_stack = None
+        self._session = None
+
+    async def list_tools(self) -> list[dict[str, Any]]:
+        """List tools provided by this MCP server.
+
+        Returns a list of dicts with name, description, and inputSchema.
+        """
+        if self._session is None:
+            raise RuntimeError(f"Plugin '{self.name}' is not connected")
+
+        response = await self._session.list_tools()
+        return [
+            {
+                "name": tool.name,
+                "description": tool.description or "",
+                "inputSchema": tool.inputSchema,
+            }
+            for tool in response.tools
+        ]
+
+    async def call_tool(
+        self, tool_name: str, arguments: dict[str, Any], timeout: float = 120.0
+    ) -> str:
+        """Call a tool on this MCP server.
+
+        Returns the text content from the tool result.
+        """
+        if self._session is None:
+            raise RuntimeError(f"Plugin '{self.name}' is not connected")
+
+        result = await asyncio.wait_for(
+            self._session.call_tool(tool_name, arguments),
+            timeout=timeout,
+        )
+
+        # Extract text content from result
+        parts: list[str] = []
+        for item in result.content:
+            if hasattr(item, "text"):
+                parts.append(item.text)
+            elif hasattr(item, "data"):
+                parts.append(f"[binary data: {getattr(item, 'mimeType', 'unknown')}]")
+            else:
+                parts.append(str(item))
+        return "\n".join(parts)
+
+    async def ping(self, timeout: float = 10.0) -> bool:
+        """Ping the MCP server to check connectivity."""
+        if self._session is None:
+            return False
+        try:
+            await asyncio.wait_for(self._session.send_ping(), timeout=timeout)
+            return True
+        except (TimeoutError, ConnectionError, OSError):
+            return False

--- a/src/mita/plugins/manager.py
+++ b/src/mita/plugins/manager.py
@@ -1,0 +1,210 @@
+"""Plugin manager — manages all MCP plugin connections and tool registration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rich.console import Console
+
+from mita.config.schema import PluginDefinition
+from mita.plugins.client import MCPPluginClient
+from mita.tools.registry import ToolHandler, ToolRegistry
+from mita.tools.schema import ToolDefinition, ToolParameter, ToolResult
+
+
+def _schema_to_parameters(input_schema: dict[str, Any]) -> list[ToolParameter]:
+    """Convert a JSON Schema inputSchema to a list of ToolParameter."""
+    properties = input_schema.get("properties", {})
+    required = set(input_schema.get("required", []))
+    params: list[ToolParameter] = []
+
+    for name, prop in properties.items():
+        params.append(
+            ToolParameter(
+                name=name,
+                type=prop.get("type", "string"),
+                description=prop.get("description", ""),
+                required=name in required,
+                default=prop.get("default"),
+            )
+        )
+    return params
+
+
+class PluginManager:
+    """Manages MCP plugin connections and exposes their tools."""
+
+    def __init__(self, plugins: list[PluginDefinition]) -> None:
+        self._plugins = plugins
+        self._clients: dict[str, MCPPluginClient] = {}
+
+    @property
+    def plugin_names(self) -> list[str]:
+        return [p.name for p in self._plugins]
+
+    def get_client(self, name: str) -> MCPPluginClient | None:
+        return self._clients.get(name)
+
+    async def start_all(self, console: Console | None = None) -> list[str]:
+        """Start all configured plugins. Returns list of successfully started plugin names."""
+        started: list[str] = []
+        for plugin in self._plugins:
+            try:
+                client = MCPPluginClient(plugin)
+                await client.connect()
+                self._clients[plugin.name] = client
+                started.append(plugin.name)
+            except (ConnectionError, OSError, TimeoutError, ValueError, RuntimeError) as e:
+                if console:
+                    console.print(f"[yellow]Plugin '{plugin.name}' failed to start: {e}[/yellow]")
+        return started
+
+    async def stop_all(self) -> None:
+        """Disconnect all running plugins."""
+        for client in self._clients.values():
+            try:
+                await client.disconnect()
+            except (ConnectionError, OSError):
+                pass
+        self._clients.clear()
+
+    async def start_plugin(self, name: str, console: Console | None = None) -> bool:
+        """Start a single plugin by name."""
+        plugin = next((p for p in self._plugins if p.name == name), None)
+        if plugin is None:
+            if console:
+                console.print(f"[red]Plugin '{name}' not found in configuration.[/red]")
+            return False
+
+        try:
+            client = MCPPluginClient(plugin)
+            await client.connect()
+            self._clients[name] = client
+            return True
+        except (ConnectionError, OSError, TimeoutError, ValueError, RuntimeError) as e:
+            if console:
+                console.print(f"[red]Plugin '{name}' failed to start: {e}[/red]")
+            return False
+
+    async def stop_plugin(self, name: str) -> None:
+        """Stop a single plugin by name."""
+        client = self._clients.pop(name, None)
+        if client is not None:
+            await client.disconnect()
+
+    async def list_tools(self, name: str | None = None) -> dict[str, list[dict[str, Any]]]:
+        """List tools from connected plugins.
+
+        Args:
+            name: If provided, list tools from this plugin only.
+
+        Returns:
+            Dict mapping plugin name to list of tool dicts.
+        """
+        result: dict[str, list[dict[str, Any]]] = {}
+        clients = {name: self._clients[name]} if name and name in self._clients else self._clients
+        for pname, client in clients.items():
+            try:
+                result[pname] = await client.list_tools()
+            except (ConnectionError, OSError, RuntimeError):
+                result[pname] = []
+        return result
+
+    def register_tools(self, registry: ToolRegistry) -> int:
+        """Register all MCP plugin tools into a ToolRegistry.
+
+        Must be called after start_all(). Returns the number of tools registered.
+        """
+        import asyncio
+
+        loop = asyncio.get_event_loop()
+        count = 0
+
+        for pname, client in self._clients.items():
+            try:
+                tools = loop.run_until_complete(client.list_tools())
+            except (ConnectionError, OSError, RuntimeError):
+                continue
+
+            for tool in tools:
+                tool_name = f"mcp:{pname}/{tool['name']}"
+                definition = ToolDefinition(
+                    name=tool_name,
+                    description=tool["description"],
+                    parameters=_schema_to_parameters(tool.get("inputSchema", {})),
+                    source=f"mcp:{pname}",
+                )
+                handler = _make_mcp_handler(client, tool["name"])
+                registry.register(definition, handler)
+                count += 1
+
+        return count
+
+    async def register_tools_async(self, registry: ToolRegistry) -> int:
+        """Async version of register_tools. Returns the number of tools registered."""
+        count = 0
+
+        for pname, client in self._clients.items():
+            try:
+                tools = await client.list_tools()
+            except (ConnectionError, OSError, RuntimeError):
+                continue
+
+            for tool in tools:
+                tool_name = f"mcp:{pname}/{tool['name']}"
+                definition = ToolDefinition(
+                    name=tool_name,
+                    description=tool["description"],
+                    parameters=_schema_to_parameters(tool.get("inputSchema", {})),
+                    source=f"mcp:{pname}",
+                )
+                handler = _make_mcp_handler(client, tool["name"])
+                registry.register(definition, handler)
+                count += 1
+
+        return count
+
+    async def test_plugin(self, name: str) -> dict[str, Any]:
+        """Test plugin connectivity. Returns status dict."""
+        client = self._clients.get(name)
+        if client is None:
+            return {"name": name, "connected": False, "error": "Not started"}
+
+        alive = await client.ping()
+        if not alive:
+            return {"name": name, "connected": True, "ping": False, "error": "Ping failed"}
+
+        try:
+            tools = await client.list_tools()
+            return {
+                "name": name,
+                "connected": True,
+                "ping": True,
+                "tools": len(tools),
+                "tool_names": [t["name"] for t in tools],
+            }
+        except (ConnectionError, OSError, RuntimeError) as e:
+            return {"name": name, "connected": True, "ping": True, "error": str(e)}
+
+
+def _make_mcp_handler(client: MCPPluginClient, remote_tool_name: str) -> ToolHandler:
+    """Create a tool handler that dispatches to an MCP plugin."""
+
+    async def handler(args: dict[str, Any]) -> ToolResult:
+        try:
+            output = await client.call_tool(remote_tool_name, args)
+            return ToolResult(tool_call_id="", success=True, output=output)
+        except TimeoutError:
+            return ToolResult(
+                tool_call_id="",
+                success=False,
+                error=f"MCP tool '{remote_tool_name}' timed out",
+            )
+        except (ConnectionError, OSError, RuntimeError) as e:
+            return ToolResult(
+                tool_call_id="",
+                success=False,
+                error=f"MCP tool '{remote_tool_name}' failed: {e}",
+            )
+
+    return handler

--- a/tests/test_plugins/test_client.py
+++ b/tests/test_plugins/test_client.py
@@ -1,0 +1,167 @@
+"""Tests for MCP plugin client."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mita.config.schema import PluginDefinition
+from mita.plugins.client import MCPPluginClient
+
+
+@pytest.fixture
+def stdio_plugin() -> PluginDefinition:
+    return PluginDefinition(
+        name="test-plugin",
+        transport="stdio",
+        command="echo",
+        args=["hello"],
+    )
+
+
+@pytest.fixture
+def sse_plugin() -> PluginDefinition:
+    return PluginDefinition(
+        name="test-sse",
+        transport="sse",
+        url="http://localhost:3001/sse",
+    )
+
+
+class TestMCPPluginClient:
+    def test_init(self, stdio_plugin: PluginDefinition) -> None:
+        client = MCPPluginClient(stdio_plugin)
+        assert client.name == "test-plugin"
+        assert client.transport == "stdio"
+        assert not client.connected
+
+    def test_missing_command_raises(self) -> None:
+        plugin = PluginDefinition(name="bad", transport="stdio")
+        client = MCPPluginClient(plugin)
+        with pytest.raises(ValueError, match="requires a command"):
+            import asyncio
+
+            asyncio.get_event_loop().run_until_complete(client.connect())
+
+    def test_missing_url_raises(self) -> None:
+        plugin = PluginDefinition(name="bad", transport="sse")
+        client = MCPPluginClient(plugin)
+        with pytest.raises(ValueError, match="requires a url"):
+            import asyncio
+
+            asyncio.get_event_loop().run_until_complete(client.connect())
+
+    def test_unsupported_transport_raises(self) -> None:
+        plugin = PluginDefinition(name="bad", transport="grpc")
+        client = MCPPluginClient(plugin)
+        with pytest.raises(ValueError, match="Unsupported transport"):
+            import asyncio
+
+            asyncio.get_event_loop().run_until_complete(client.connect())
+
+    @pytest.mark.asyncio
+    async def test_list_tools_not_connected(self, stdio_plugin: PluginDefinition) -> None:
+        client = MCPPluginClient(stdio_plugin)
+        with pytest.raises(RuntimeError, match="not connected"):
+            await client.list_tools()
+
+    @pytest.mark.asyncio
+    async def test_call_tool_not_connected(self, stdio_plugin: PluginDefinition) -> None:
+        client = MCPPluginClient(stdio_plugin)
+        with pytest.raises(RuntimeError, match="not connected"):
+            await client.call_tool("test", {})
+
+    @pytest.mark.asyncio
+    async def test_ping_not_connected(self, stdio_plugin: PluginDefinition) -> None:
+        client = MCPPluginClient(stdio_plugin)
+        assert not await client.ping()
+
+    @pytest.mark.asyncio
+    async def test_connect_stdio(self, stdio_plugin: PluginDefinition) -> None:
+        mock_session = AsyncMock()
+        mock_session.initialize = AsyncMock()
+
+        mock_transport = (MagicMock(), MagicMock())
+
+        with (
+            patch("mita.plugins.client.stdio_client") as mock_stdio,
+            patch("mita.plugins.client.ClientSession", return_value=mock_session),
+        ):
+            # stdio_client returns an async context manager yielding transport
+            mock_cm = AsyncMock()
+            mock_cm.__aenter__ = AsyncMock(return_value=mock_transport)
+            mock_cm.__aexit__ = AsyncMock(return_value=False)
+            mock_stdio.return_value = mock_cm
+
+            # ClientSession also an async context manager
+            mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session.__aexit__ = AsyncMock(return_value=False)
+
+            client = MCPPluginClient(stdio_plugin)
+            await client.connect()
+
+            assert client.connected
+            mock_session.initialize.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_list_tools_with_session(self, stdio_plugin: PluginDefinition) -> None:
+        mock_tool = MagicMock()
+        mock_tool.name = "read_file"
+        mock_tool.description = "Read a file"
+        mock_tool.inputSchema = {"type": "object", "properties": {"path": {"type": "string"}}}
+
+        mock_response = MagicMock()
+        mock_response.tools = [mock_tool]
+
+        client = MCPPluginClient(stdio_plugin)
+        client._session = AsyncMock()
+        client._session.list_tools = AsyncMock(return_value=mock_response)
+
+        tools = await client.list_tools()
+        assert len(tools) == 1
+        assert tools[0]["name"] == "read_file"
+        assert tools[0]["description"] == "Read a file"
+
+    @pytest.mark.asyncio
+    async def test_call_tool_with_session(self, stdio_plugin: PluginDefinition) -> None:
+        mock_content = MagicMock()
+        mock_content.text = "file contents here"
+
+        mock_result = MagicMock()
+        mock_result.content = [mock_content]
+
+        client = MCPPluginClient(stdio_plugin)
+        client._session = AsyncMock()
+        client._session.call_tool = AsyncMock(return_value=mock_result)
+
+        output = await client.call_tool("read_file", {"path": "/tmp/test.txt"})
+        assert output == "file contents here"
+        client._session.call_tool.assert_awaited_once_with("read_file", {"path": "/tmp/test.txt"})
+
+    @pytest.mark.asyncio
+    async def test_disconnect(self, stdio_plugin: PluginDefinition) -> None:
+        client = MCPPluginClient(stdio_plugin)
+        client._session = AsyncMock()
+        client._exit_stack = AsyncMock()
+        client._exit_stack.aclose = AsyncMock()
+
+        await client.disconnect()
+        assert client._session is None
+        assert client._exit_stack is None
+
+    @pytest.mark.asyncio
+    async def test_ping_success(self, stdio_plugin: PluginDefinition) -> None:
+        client = MCPPluginClient(stdio_plugin)
+        client._session = AsyncMock()
+        client._session.send_ping = AsyncMock()
+
+        assert await client.ping()
+
+    @pytest.mark.asyncio
+    async def test_ping_timeout(self, stdio_plugin: PluginDefinition) -> None:
+        client = MCPPluginClient(stdio_plugin)
+        client._session = AsyncMock()
+        client._session.send_ping = AsyncMock(side_effect=TimeoutError)
+
+        assert not await client.ping()

--- a/tests/test_plugins/test_manager.py
+++ b/tests/test_plugins/test_manager.py
@@ -1,0 +1,268 @@
+"""Tests for MCP plugin manager."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mita.config.schema import PluginDefinition
+from mita.plugins.manager import PluginManager, _make_mcp_handler, _schema_to_parameters
+from mita.tools.registry import ToolRegistry
+from mita.tools.schema import ToolResult
+
+
+class TestSchemaToParameters:
+    def test_empty_schema(self) -> None:
+        params = _schema_to_parameters({})
+        assert params == []
+
+    def test_basic_properties(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string", "description": "File path"},
+                "lines": {"type": "integer", "description": "Number of lines"},
+            },
+            "required": ["path"],
+        }
+        params = _schema_to_parameters(schema)
+        assert len(params) == 2
+        path_param = next(p for p in params if p.name == "path")
+        assert path_param.type == "string"
+        assert path_param.required is True
+        lines_param = next(p for p in params if p.name == "lines")
+        assert lines_param.required is False
+
+    def test_default_values(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {
+                "encoding": {"type": "string", "description": "Encoding", "default": "utf-8"},
+            },
+        }
+        params = _schema_to_parameters(schema)
+        assert params[0].default == "utf-8"
+
+
+class TestMakeMCPHandler:
+    @pytest.mark.asyncio
+    async def test_success(self) -> None:
+        mock_client = AsyncMock()
+        mock_client.call_tool = AsyncMock(return_value="tool output")
+
+        handler = _make_mcp_handler(mock_client, "read_file")
+        result = await handler({"path": "/tmp/test"})
+
+        assert isinstance(result, ToolResult)
+        assert result.success is True
+        assert result.output == "tool output"
+
+    @pytest.mark.asyncio
+    async def test_timeout(self) -> None:
+        mock_client = AsyncMock()
+        mock_client.call_tool = AsyncMock(side_effect=TimeoutError)
+
+        handler = _make_mcp_handler(mock_client, "slow_tool")
+        result = await handler({})
+
+        assert result.success is False
+        assert "timed out" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_connection_error(self) -> None:
+        mock_client = AsyncMock()
+        mock_client.call_tool = AsyncMock(side_effect=ConnectionError("dead"))
+
+        handler = _make_mcp_handler(mock_client, "broken_tool")
+        result = await handler({})
+
+        assert result.success is False
+        assert "failed" in (result.error or "")
+
+
+class TestPluginManager:
+    @pytest.fixture
+    def plugins(self) -> list[PluginDefinition]:
+        return [
+            PluginDefinition(name="fs", transport="stdio", command="npx", args=["@mcp/fs"]),
+            PluginDefinition(name="web", transport="sse", url="http://localhost:3001/sse"),
+        ]
+
+    def test_plugin_names(self, plugins: list[PluginDefinition]) -> None:
+        mgr = PluginManager(plugins)
+        assert mgr.plugin_names == ["fs", "web"]
+
+    def test_get_client_none(self, plugins: list[PluginDefinition]) -> None:
+        mgr = PluginManager(plugins)
+        assert mgr.get_client("fs") is None
+
+    @pytest.mark.asyncio
+    async def test_start_all_with_failures(self) -> None:
+        plugins = [
+            PluginDefinition(name="good", transport="stdio", command="echo"),
+            PluginDefinition(name="bad", transport="stdio"),  # missing command
+        ]
+        mgr = PluginManager(plugins)
+
+        with patch.object(mgr, "start_all", new_callable=AsyncMock, return_value=["good"]):
+            started = await mgr.start_all()
+            assert "good" in started
+
+    @pytest.mark.asyncio
+    async def test_stop_all(self) -> None:
+        mgr = PluginManager([])
+        mock_client = AsyncMock()
+        mock_client.disconnect = AsyncMock()
+        mgr._clients["test"] = mock_client
+
+        await mgr.stop_all()
+        assert len(mgr._clients) == 0
+        mock_client.disconnect.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_list_tools(self) -> None:
+        mgr = PluginManager([])
+        mock_client = AsyncMock()
+        mock_client.list_tools = AsyncMock(
+            return_value=[{"name": "read", "description": "Read file", "inputSchema": {}}]
+        )
+        mgr._clients["fs"] = mock_client
+
+        result = await mgr.list_tools()
+        assert "fs" in result
+        assert len(result["fs"]) == 1
+        assert result["fs"][0]["name"] == "read"
+
+    @pytest.mark.asyncio
+    async def test_list_tools_single_plugin(self) -> None:
+        mgr = PluginManager([])
+        mock_client = AsyncMock()
+        mock_client.list_tools = AsyncMock(return_value=[])
+        mgr._clients["fs"] = mock_client
+        mgr._clients["web"] = AsyncMock()
+
+        result = await mgr.list_tools("fs")
+        assert "fs" in result
+        assert "web" not in result
+
+    @pytest.mark.asyncio
+    async def test_register_tools_async(self) -> None:
+        mgr = PluginManager([])
+        mock_client = AsyncMock()
+        mock_client.list_tools = AsyncMock(
+            return_value=[
+                {
+                    "name": "read_file",
+                    "description": "Read a file",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {"path": {"type": "string", "description": "path"}},
+                        "required": ["path"],
+                    },
+                }
+            ]
+        )
+        mgr._clients["fs"] = mock_client
+
+        registry = ToolRegistry()
+        count = await mgr.register_tools_async(registry)
+
+        assert count == 1
+        assert registry.has_tool("mcp:fs/read_file")
+        defn = registry.get_definition("mcp:fs/read_file")
+        assert defn is not None
+        assert defn.source == "mcp:fs"
+        assert len(defn.parameters) == 1
+
+    @pytest.mark.asyncio
+    async def test_test_plugin_not_started(self) -> None:
+        mgr = PluginManager([])
+        result = await mgr.test_plugin("missing")
+        assert result["connected"] is False
+
+    @pytest.mark.asyncio
+    async def test_test_plugin_healthy(self) -> None:
+        mgr = PluginManager([])
+        mock_client = AsyncMock()
+        mock_client.ping = AsyncMock(return_value=True)
+        mock_client.list_tools = AsyncMock(
+            return_value=[{"name": "tool1", "description": "desc", "inputSchema": {}}]
+        )
+        mgr._clients["fs"] = mock_client
+
+        result = await mgr.test_plugin("fs")
+        assert result["ping"] is True
+        assert result["tools"] == 1
+
+    @pytest.mark.asyncio
+    async def test_test_plugin_ping_failed(self) -> None:
+        mgr = PluginManager([])
+        mock_client = AsyncMock()
+        mock_client.ping = AsyncMock(return_value=False)
+        mgr._clients["fs"] = mock_client
+
+        result = await mgr.test_plugin("fs")
+        assert result["ping"] is False
+
+    @pytest.mark.asyncio
+    async def test_start_plugin(self) -> None:
+        plugin = PluginDefinition(name="test", transport="stdio", command="echo")
+        mgr = PluginManager([plugin])
+
+        with patch("mita.plugins.manager.MCPPluginClient") as mock_cls:
+            mock_instance = AsyncMock()
+            mock_instance.connect = AsyncMock()
+            mock_cls.return_value = mock_instance
+
+            result = await mgr.start_plugin("test")
+            assert result is True
+            assert mgr.get_client("test") is mock_instance
+
+    @pytest.mark.asyncio
+    async def test_start_plugin_not_configured(self) -> None:
+        mgr = PluginManager([])
+        result = await mgr.start_plugin("missing")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_stop_plugin(self) -> None:
+        mgr = PluginManager([])
+        mock_client = AsyncMock()
+        mock_client.disconnect = AsyncMock()
+        mgr._clients["test"] = mock_client
+
+        await mgr.stop_plugin("test")
+        assert mgr.get_client("test") is None
+        mock_client.disconnect.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_tool_execution_via_registry(self) -> None:
+        """End-to-end: register MCP tool, then execute via registry."""
+        mgr = PluginManager([])
+        mock_client = AsyncMock()
+        mock_client.list_tools = AsyncMock(
+            return_value=[
+                {
+                    "name": "greet",
+                    "description": "Greet someone",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {"name": {"type": "string", "description": "Name"}},
+                    },
+                }
+            ]
+        )
+        mock_client.call_tool = AsyncMock(return_value="Hello, World!")
+        mgr._clients["greeter"] = mock_client
+
+        registry = ToolRegistry()
+        await mgr.register_tools_async(registry)
+
+        from mita.tools.schema import ToolCall
+
+        result = await registry.execute(
+            ToolCall(id="tc1", name="mcp:greeter/greet", arguments={"name": "World"})
+        )
+        assert result.success is True
+        assert result.output == "Hello, World!"


### PR DESCRIPTION
## Summary

- Implements the MCP (Model Context Protocol) plugin system (Issue #7)
- Users can configure external MCP servers (stdio or SSE transport) in `.mita/settings.toml`
- Agent automatically discovers and can call MCP tools during chat sessions
- New CLI commands: `mita plugins list`, `mita plugins add`, `mita plugins remove`, `mita plugins test`

## Changes

- **New `src/mita/plugins/` module**: `client.py` (single MCP server connection with stdio/SSE transport, AsyncExitStack lifecycle), `manager.py` (multi-plugin manager, tool registration into ToolRegistry)
- **`src/mita/agent/loop.py`**: Auto-loads MCP plugin tools when plugins are configured
- **`src/mita/cli.py`**: Plugin management CLI commands
- **`pyproject.toml`**: Added `mcp>=1.0.0` dependency
- **33 new tests** covering client connection, tool listing, tool calling, ping, manager lifecycle, tool registration, and end-to-end tool execution via registry

## Configuration Example

```toml
[[plugins]]
name = "filesystem"
transport = "stdio"
command = "npx"
args = ["@modelcontextprotocol/server-filesystem", "/home/user"]

[[plugins]]
name = "web-search"
transport = "sse"
url = "http://localhost:3001/sse"
```

## Test plan

- [x] 376 tests passing (33 new plugin tests)
- [x] `invoke check` passes (ruff, mypy, pytest)
- [ ] Manual: configure a stdio MCP server, verify `mita plugins list` shows tools
- [x] Manual: verify agent can call MCP tools during `mita chat`
- [x] Manual: verify `mita plugins test <name>` reports connectivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)