### PR TITLE
feat: Phase 9 polish and non-interactive mode

### DIFF
--- a/src/mita/agent/loop.py
+++ b/src/mita/agent/loop.py
@@ -101,85 +101,97 @@ async def run_agent(
     last_tool_signature: str | None = None
     repeat_count = 0
     for iteration in range(MAX_ITERATIONS):
-        # Truncate to fit context window
-        conversation.truncate_to_fit(config.model.context_window)
+        try:
+            # Truncate to fit context window
+            conversation.truncate_to_fit(config.model.context_window)
 
-        # Call LLM with tool schemas so the model can produce structured tool calls
-        messages = conversation.get_messages_for_api()
-        tool_schemas = registry.get_openai_schemas()
+            # Call LLM with tool schemas so the model can produce structured tool calls
+            messages = conversation.get_messages_for_api()
+            tool_schemas = registry.get_openai_schemas()
 
-        if config.ui.stream:
-            assistant_text, tool_calls_raw, stats = await _stream_response(
-                llm_client, messages, tool_schemas, console
-            )
-            if config.ui.show_token_count:
-                display_response_stats(
-                    console,
-                    prompt_tokens=stats.prompt_tokens,
-                    completion_tokens=stats.completion_tokens,
-                    total_time=stats.total_time,
-                    ttft=stats.ttft,
+            if config.ui.stream:
+                assistant_text, tool_calls_raw, stats = await _stream_response(
+                    llm_client, messages, tool_schemas, console
                 )
-        else:
-            t0 = time.monotonic()
-            with thinking_spinner(console):
-                response = await llm_client.chat(messages, tools=tool_schemas)
-            elapsed = time.monotonic() - t0
-            assistant_text, tool_calls_raw = _parse_response(response)
-            if assistant_text:
-                display_markdown(console, assistant_text)
-            if config.ui.show_token_count:
-                usage = _extract_usage(response) or {}
-                display_response_stats(
-                    console,
-                    prompt_tokens=usage.get("prompt_tokens", 0),
-                    completion_tokens=usage.get("completion_tokens", 0),
-                    total_time=elapsed,
-                )
-
-        # Fallback: parse tool calls from text if model didn't use native calling
-        if not tool_calls_raw and assistant_text:
-            parsed, remaining_text = _extract_tool_calls_from_text(assistant_text, registry)
-            if parsed:
-                tool_calls_raw = parsed
-                assistant_text = remaining_text
-
-        # Handle tool calls
-        if tool_calls_raw:
-            # Detect repeated identical tool calls (model stuck in a loop)
-            sig = json.dumps(
-                [
-                    (tc.get("function", {}).get("name"), tc.get("function", {}).get("arguments"))
-                    for tc in tool_calls_raw
-                ],
-                sort_keys=True,
-            )
-            if sig == last_tool_signature:
-                repeat_count += 1
-                if repeat_count >= 1:
-                    display_error(
+                if config.ui.show_token_count:
+                    display_response_stats(
                         console,
-                        "Detected repeated tool call — stopping to avoid infinite loop.",
+                        prompt_tokens=stats.prompt_tokens,
+                        completion_tokens=stats.completion_tokens,
+                        total_time=stats.total_time,
+                        ttft=stats.ttft,
                     )
-                    conversation.add(Message(role=Role.ASSISTANT, content=assistant_text))
-                    break
             else:
-                repeat_count = 0
-            last_tool_signature = sig
+                t0 = time.monotonic()
+                with thinking_spinner(console):
+                    response = await llm_client.chat(messages, tools=tool_schemas)
+                elapsed = time.monotonic() - t0
+                assistant_text, tool_calls_raw = _parse_response(response)
+                if assistant_text:
+                    display_markdown(console, assistant_text)
+                if config.ui.show_token_count:
+                    usage = _extract_usage(response) or {}
+                    display_response_stats(
+                        console,
+                        prompt_tokens=usage.get("prompt_tokens", 0),
+                        completion_tokens=usage.get("completion_tokens", 0),
+                        total_time=elapsed,
+                    )
 
-            conversation.add(
-                Message(
-                    role=Role.ASSISTANT,
-                    content=assistant_text,
-                    tool_calls=tool_calls_raw,
+            # Fallback: parse tool calls from text if model didn't use native calling
+            if not tool_calls_raw and assistant_text:
+                parsed, remaining_text = _extract_tool_calls_from_text(assistant_text, registry)
+                if parsed:
+                    tool_calls_raw = parsed
+                    assistant_text = remaining_text
+
+            # Handle tool calls
+            if tool_calls_raw:
+                # Detect repeated identical tool calls (model stuck in a loop)
+                sig = json.dumps(
+                    [
+                        (
+                            tc.get("function", {}).get("name"),
+                            tc.get("function", {}).get("arguments"),
+                        )
+                        for tc in tool_calls_raw
+                    ],
+                    sort_keys=True,
                 )
-            )
-            await _process_tool_calls(tool_calls_raw, conversation, registry, config, console)
-            continue
+                if sig == last_tool_signature:
+                    repeat_count += 1
+                    if repeat_count >= 1:
+                        display_error(
+                            console,
+                            "Detected repeated tool call — stopping to avoid infinite loop.",
+                        )
+                        conversation.add(Message(role=Role.ASSISTANT, content=assistant_text))
+                        break
+                else:
+                    repeat_count = 0
+                last_tool_signature = sig
 
-        # No tool calls — add assistant message and stop
-        conversation.add(Message(role=Role.ASSISTANT, content=assistant_text))
-        break
+                conversation.add(
+                    Message(
+                        role=Role.ASSISTANT,
+                        content=assistant_text,
+                        tool_calls=tool_calls_raw,
+                    )
+                )
+                await _process_tool_calls(tool_calls_raw, conversation, registry, config, console)
+                continue
+
+            # No tool calls — add assistant message and stop
+            conversation.add(Message(role=Role.ASSISTANT, content=assistant_text))
+            break
+
+        except KeyboardInterrupt:
+            display_error(console, "[Interrupted]")
+            # Add any partial response as assistant message
+            partial = locals().get("assistant_text", "")
+            if partial:
+                conversation.add(Message(role=Role.ASSISTANT, content=str(partial)))
+            break
     else:
         display_error(
             console,

--- a/src/mita/cli.py
+++ b/src/mita/cli.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import enum
+import sys
+from io import StringIO
 from typing import Annotated
 
 import typer
@@ -29,6 +32,14 @@ app = typer.Typer(
     no_args_is_help=True,
     add_completion=True,
 )
+
+
+class OutputFormat(enum.StrEnum):
+    """Output format for non-interactive ask command."""
+
+    RICH = "rich"
+    TEXT = "text"
+    JSON = "json"
 
 
 # ── Version ───────────────────────────────────────────────────────
@@ -564,7 +575,12 @@ def ollama_status() -> None:
 
 
 @app.command("chat")
-def chat_command() -> None:
+def chat_command(
+    no_tools: Annotated[
+        bool,
+        typer.Option("--no-tools", help="Disable all tools."),
+    ] = False,
+) -> None:
     """Open an interactive chat session with the agent."""
     import asyncio
 
@@ -572,6 +588,7 @@ def chat_command() -> None:
     from mita.agent.loop import run_agent
     from mita.config.loader import load_config as _load_config
     from mita.models.server import ensure_model, ensure_server
+    from mita.tools.registry import ToolRegistry, create_default_registry
     from mita.ui.display import get_console
     from mita.ui.repl import repl_loop
 
@@ -589,17 +606,16 @@ def chat_command() -> None:
         raise typer.Exit(1)
 
     from mita.plugins.manager import PluginManager
-    from mita.tools.registry import create_default_registry
 
     conversation = Conversation()
-    registry = create_default_registry()
+    registry: ToolRegistry = ToolRegistry() if no_tools else create_default_registry()
 
     async def _run_chat() -> None:
         nonlocal conversation
 
         # Start MCP plugins at session level (not per-call)
         plugin_mgr: PluginManager | None = None
-        if cfg.plugins:
+        if cfg.plugins and not no_tools:
             plugin_mgr = PluginManager(cfg.plugins)
             await plugin_mgr.start_all(console=chat_console)
             await plugin_mgr.register_tools_async(registry)
@@ -628,18 +644,60 @@ def chat_command() -> None:
 
 @app.command("ask")
 def ask_command(
-    prompt: Annotated[str, typer.Argument(help="The prompt to send to the agent.")],
+    prompt: Annotated[
+        str | None,
+        typer.Argument(help="The prompt to send to the agent."),
+    ] = None,
+    output: Annotated[
+        OutputFormat | None,
+        typer.Option("--output", "-o", help="Output format: rich, text, or json."),
+    ] = None,
+    no_tools: Annotated[
+        bool,
+        typer.Option("--no-tools", help="Disable all tools."),
+    ] = False,
 ) -> None:
     """Send a single prompt to the agent (non-interactive)."""
     import asyncio
+    import json
 
+    from mita.agent.conversation import Conversation, Role
     from mita.agent.loop import run_agent
     from mita.config.loader import load_config as _load_config
     from mita.models.server import ensure_model, ensure_server
+    from mita.tools.registry import ToolRegistry, create_default_registry
     from mita.ui.display import get_console
 
+    # Assemble prompt from argument and/or stdin
+    parts: list[str] = []
+    if prompt is not None:
+        parts.append(prompt)
+    if not sys.stdin.isatty():
+        stdin_text = sys.stdin.read().strip()
+        if stdin_text:
+            parts.append(stdin_text)
+    if not parts:
+        console.print("[red]No prompt provided. Pass a prompt argument or pipe via stdin.[/red]")
+        raise typer.Exit(1)
+
+    full_prompt = "\n".join(parts)
+
+    # Resolve output format: explicit flag wins, else auto-detect
+    effective_output = output
+    if effective_output is None:
+        effective_output = OutputFormat.TEXT if not sys.stdout.isatty() else OutputFormat.RICH
+
     cfg = _load_config()
-    ask_console = get_console()
+
+    # Build the console for this run
+    if effective_output == OutputFormat.TEXT:
+        ask_console = Console(no_color=True, highlight=False)
+        cfg.ui.stream = False
+    elif effective_output == OutputFormat.JSON:
+        ask_console = Console(file=StringIO(), no_color=True, highlight=False)
+        cfg.ui.stream = False
+    else:
+        ask_console = get_console()
 
     if not ensure_server(
         host=cfg.ollama.host, auto_manage=cfg.ollama.auto_manage, console=ask_console
@@ -651,25 +709,173 @@ def ask_command(
     ):
         raise typer.Exit(1)
 
-    async def _run_ask() -> None:
+    async def _run_ask() -> Conversation:
         from mita.plugins.manager import PluginManager
-        from mita.tools.registry import create_default_registry
 
-        registry = create_default_registry()
+        registry: ToolRegistry = ToolRegistry() if no_tools else create_default_registry()
 
         plugin_mgr: PluginManager | None = None
-        if cfg.plugins:
+        if cfg.plugins and not no_tools:
             plugin_mgr = PluginManager(cfg.plugins)
             await plugin_mgr.start_all(console=ask_console)
             await plugin_mgr.register_tools_async(registry)
 
         try:
-            await run_agent(prompt, cfg, ask_console, registry=registry)
+            return await run_agent(full_prompt, cfg, ask_console, registry=registry)
         finally:
             if plugin_mgr is not None:
                 await plugin_mgr.stop_all()
 
-    asyncio.run(_run_ask())
+    conversation = asyncio.run(_run_ask())
+
+    # Extract the last assistant message
+    last_assistant = ""
+    for msg in reversed(conversation.messages):
+        if msg.role == Role.ASSISTANT and msg.content:
+            last_assistant = msg.content
+            break
+
+    if effective_output == OutputFormat.TEXT:
+        print(last_assistant)  # noqa: T201
+    elif effective_output == OutputFormat.JSON:
+        print(  # noqa: T201
+            json.dumps({"response": last_assistant, "model": cfg.model.default})
+        )
+
+
+# ── Doctor command ────────────────────────────────────────────────
+
+
+@app.command("doctor")
+def doctor_command() -> None:
+    """Check system health and configuration."""
+    import platform
+
+    from mita.ui.display import display_error_with_suggestion
+
+    doc_console = Console()
+
+    # 1. Python version
+    py_ver = platform.python_version()
+    py_tuple = tuple(int(x) for x in py_ver.split(".")[:2])
+    if py_tuple >= (3, 11):
+        doc_console.print(f"  [green]\u2713[/green] Python {py_ver}")
+    else:
+        doc_console.print(f"  [red]\u2717[/red] Python {py_ver}")
+        display_error_with_suggestion(
+            doc_console,
+            "Python 3.11+ is required",
+            "Install Python 3.11 or later",
+        )
+
+    # 2. Ollama binary
+    from mita.models.server import find_ollama_binary
+
+    binary = find_ollama_binary()
+    if binary:
+        doc_console.print(f"  [green]\u2713[/green] Ollama binary found ({binary})")
+    else:
+        doc_console.print("  [red]\u2717[/red] Ollama binary not found")
+        display_error_with_suggestion(
+            doc_console,
+            "Ollama is not installed",
+            "Install from https://ollama.com",
+        )
+
+    # 3. Ollama server running
+    from mita.models.server import is_server_running
+
+    cfg = load_config()
+    if is_server_running(cfg.ollama.host):
+        doc_console.print("  [green]\u2713[/green] Ollama server running")
+    else:
+        doc_console.print("  [red]\u2717[/red] Ollama not running")
+        display_error_with_suggestion(
+            doc_console,
+            "Ollama server is not running",
+            "Run 'mita ollama start' or 'ollama serve'",
+        )
+
+    # 4. Default model installed
+    _check_model_installed(doc_console, cfg.model.default, "Default model", cfg)
+
+    # 5. Embedding model installed
+    _check_model_installed(doc_console, cfg.model.embedding, "Embedding model", cfg)
+
+    # 6. Config loads without error
+    try:
+        load_config()
+        doc_console.print("  [green]\u2713[/green] Config loaded successfully")
+    except Exception as exc:
+        doc_console.print("  [red]\u2717[/red] Config load error")
+        display_error_with_suggestion(
+            doc_console,
+            f"Config error: {exc}",
+            "Check ~/.config/mita/config.toml and .mita/settings.toml",
+        )
+
+    # 7. Memory files discoverable
+    from mita.memory.discovery import discover_memory_files
+
+    mem_files = discover_memory_files()
+    if mem_files:
+        doc_console.print(f"  [green]\u2713[/green] Memory files found ({len(mem_files)})")
+    else:
+        doc_console.print("  [yellow]![/yellow] No MITA.md memory files found")
+
+    # 8. Index exists
+    from pathlib import Path
+
+    from mita.index.store import IndexStore
+
+    index_dir = Path.cwd() / ".mita" / "index"
+    store = IndexStore(index_dir)
+    if store.exists():
+        doc_console.print("  [green]\u2713[/green] Codebase index exists")
+    else:
+        doc_console.print("  [yellow]![/yellow] No codebase index")
+        display_error_with_suggestion(
+            doc_console,
+            "Codebase index not built",
+            "Run 'mita index build' to create it",
+        )
+
+
+def _check_model_installed(doc_console: Console, model_name: str, label: str, cfg: object) -> None:
+    """Check if an Ollama model is installed and print status."""
+    from mita.config.schema import MitaConfig
+    from mita.models.ollama_client import OllamaClient
+    from mita.models.server import is_server_running
+    from mita.ui.display import display_error_with_suggestion
+
+    assert isinstance(cfg, MitaConfig)
+
+    if not is_server_running(cfg.ollama.host):
+        doc_console.print(
+            f"  [yellow]![/yellow] {label} ({model_name}) — cannot check (server not running)"
+        )
+        return
+
+    try:
+        client = OllamaClient(host=cfg.ollama.host, timeout=cfg.ollama.timeout)
+        installed = client.list_models()
+        found = any(
+            m.name == model_name
+            or m.name == f"{model_name}:latest"
+            or m.name.split(":")[0] == model_name.split(":")[0]
+            for m in installed
+        )
+        if found:
+            doc_console.print(f"  [green]\u2713[/green] {label} ({model_name}) installed")
+        else:
+            doc_console.print(f"  [red]\u2717[/red] {label} ({model_name}) not installed")
+            display_error_with_suggestion(
+                doc_console,
+                f"{label} '{model_name}' is not installed",
+                f"Run 'mita models pull {model_name}'",
+            )
+    except (ConnectionError, OSError):
+        doc_console.print(f"  [yellow]![/yellow] {label} ({model_name}) — cannot check")
 
 
 # ── Helpers ───────────────────────────────────────────────────────

--- a/src/mita/ui/display.py
+++ b/src/mita/ui/display.py
@@ -119,6 +119,12 @@ def display_response_stats(
     console.print(f"[mita.token_count]({' · '.join(parts)})[/mita.token_count]")
 
 
+def display_error_with_suggestion(console: Console, error: str, suggestion: str) -> None:
+    """Display an error with an actionable suggestion."""
+    console.print(f"[red]{error}[/red]")
+    console.print(f"[dim]  → {suggestion}[/dim]")
+
+
 async def prompt_user_confirm(console: Console, question: str) -> bool:
     """Ask the user for confirmation before a destructive action.
 

--- a/src/mita/ui/repl.py
+++ b/src/mita/ui/repl.py
@@ -58,10 +58,16 @@ async def repl_loop(
         if user_input.startswith("/") and user_input.split()[0].lower() not in _BUILTIN_COMMANDS:
             rendered = _try_render_skill(user_input, skills_paths or [], console)
             if rendered is not None:
-                await on_input(rendered)
+                try:
+                    await on_input(rendered)
+                except KeyboardInterrupt:
+                    console.print("\n[Interrupted]")
                 continue
 
-        await on_input(user_input)
+        try:
+            await on_input(user_input)
+        except KeyboardInterrupt:
+            console.print("\n[Interrupted]")
 
 
 def _try_render_skill(user_input: str, skills_paths: list[str], console: Console) -> str | None:

--- a/tests/test_agent/test_loop.py
+++ b/tests/test_agent/test_loop.py
@@ -269,3 +269,62 @@ class TestExtractToolCallsFromText:
         calls, remaining = _extract_tool_calls_from_text("", registry)
         assert len(calls) == 0
         assert remaining == ""
+
+
+class TestKeyboardInterrupt:
+    @pytest.mark.asyncio()
+    async def test_interrupt_during_llm_call(self) -> None:
+        """KeyboardInterrupt during LLM call is caught and loop exits."""
+        config = MitaConfig()
+        config.ui.stream = False
+        mock_console = MagicMock()
+        mock_console.print = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.chat = AsyncMock(side_effect=KeyboardInterrupt)
+
+        registry = create_default_registry()
+
+        with patch("mita.agent.loop.assemble_context"):
+            conv = Conversation()
+            conv.add(Message(role=Role.SYSTEM, content="system"))
+            result = await run_agent(
+                "test",
+                config,
+                mock_console,
+                conversation=conv,
+                registry=registry,
+                llm_client=mock_client,
+            )
+
+        # Should have user message but loop should have exited gracefully
+        user_msgs = [m for m in result.messages if m.role == Role.USER]
+        assert len(user_msgs) == 1
+
+    @pytest.mark.asyncio()
+    async def test_interrupt_preserves_conversation(self) -> None:
+        """After KeyboardInterrupt, the conversation is returned."""
+        config = MitaConfig()
+        config.ui.stream = False
+        mock_console = MagicMock()
+        mock_console.print = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.chat = AsyncMock(side_effect=KeyboardInterrupt)
+
+        registry = create_default_registry()
+
+        with patch("mita.agent.loop.assemble_context"):
+            conv = Conversation()
+            conv.add(Message(role=Role.SYSTEM, content="system"))
+            result = await run_agent(
+                "test prompt",
+                config,
+                mock_console,
+                conversation=conv,
+                registry=registry,
+                llm_client=mock_client,
+            )
+
+        assert isinstance(result, Conversation)
+        assert len(result.messages) >= 2  # system + user at minimum

--- a/tests/test_cli/test_ask.py
+++ b/tests/test_cli/test_ask.py
@@ -1,0 +1,151 @@
+"""Tests for the mita ask command (non-interactive mode)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+from typer.testing import CliRunner
+
+from mita.agent.conversation import Conversation, Message, Role
+from mita.cli import OutputFormat, app
+
+runner = CliRunner()
+
+
+class TestOutputFormatEnum:
+    def test_values(self) -> None:
+        assert OutputFormat.RICH == "rich"
+        assert OutputFormat.TEXT == "text"
+        assert OutputFormat.JSON == "json"
+
+
+def _make_conv(response: str) -> Conversation:
+    conv = Conversation()
+    conv.add(Message(role=Role.SYSTEM, content="system"))
+    conv.add(Message(role=Role.USER, content="test"))
+    conv.add(Message(role=Role.ASSISTANT, content=response))
+    return conv
+
+
+class TestAskStdinDetection:
+    def test_stdin_pipe(self) -> None:
+        """When stdin is not a TTY, read prompt from stdin."""
+        conv = _make_conv("piped response")
+
+        with (
+            patch("mita.cli.sys") as mock_sys,
+            patch(
+                "mita.agent.loop.run_agent",
+                new_callable=AsyncMock,
+                return_value=conv,
+            ),
+            patch("mita.models.server.ensure_server", return_value=True),
+            patch("mita.models.server.ensure_model", return_value=True),
+        ):
+            mock_sys.stdin.isatty.return_value = False
+            mock_sys.stdin.read.return_value = "hello from pipe"
+            mock_sys.stdout.isatty.return_value = True
+            result = runner.invoke(app, ["ask", "--output", "text"])
+            assert result.exit_code == 0
+
+    def test_no_input_error(self) -> None:
+        """When no prompt and stdin is a TTY, show error."""
+        with patch("mita.cli.sys") as mock_sys:
+            mock_sys.stdin.isatty.return_value = True
+            mock_sys.stdout.isatty.return_value = True
+            result = runner.invoke(app, ["ask"])
+            assert result.exit_code != 0
+            assert "No prompt" in result.output
+
+    def test_arg_and_stdin_concatenated(self) -> None:
+        """When both arg and stdin are provided, they are concatenated."""
+        conv = _make_conv("combined")
+
+        with (
+            patch("mita.cli.sys") as mock_sys,
+            patch(
+                "mita.agent.loop.run_agent",
+                new_callable=AsyncMock,
+                return_value=conv,
+            ),
+            patch("mita.models.server.ensure_server", return_value=True),
+            patch("mita.models.server.ensure_model", return_value=True),
+        ):
+            mock_sys.stdin.isatty.return_value = False
+            mock_sys.stdin.read.return_value = "stdin part"
+            mock_sys.stdout.isatty.return_value = True
+            result = runner.invoke(app, ["ask", "arg part", "--output", "text"])
+            assert result.exit_code == 0
+
+
+class TestAskOutputModes:
+    def test_output_text(self) -> None:
+        """--output text prints plain text to stdout."""
+        conv = _make_conv("plain text answer")
+
+        with (
+            patch("mita.cli.sys") as mock_sys,
+            patch(
+                "mita.agent.loop.run_agent",
+                new_callable=AsyncMock,
+                return_value=conv,
+            ),
+            patch("mita.models.server.ensure_server", return_value=True),
+            patch("mita.models.server.ensure_model", return_value=True),
+        ):
+            mock_sys.stdin.isatty.return_value = True
+            mock_sys.stdout.isatty.return_value = True
+            result = runner.invoke(app, ["ask", "test prompt", "--output", "text"])
+            assert result.exit_code == 0
+            assert "plain text answer" in result.output
+
+    def test_output_json(self) -> None:
+        """--output json prints JSON with response and model."""
+        conv = _make_conv("json answer")
+
+        with (
+            patch("mita.cli.sys") as mock_sys,
+            patch(
+                "mita.agent.loop.run_agent",
+                new_callable=AsyncMock,
+                return_value=conv,
+            ),
+            patch("mita.models.server.ensure_server", return_value=True),
+            patch("mita.models.server.ensure_model", return_value=True),
+        ):
+            mock_sys.stdin.isatty.return_value = True
+            mock_sys.stdout.isatty.return_value = True
+            result = runner.invoke(app, ["ask", "test prompt", "--output", "json"])
+            assert result.exit_code == 0
+            data = json.loads(result.output.strip())
+            assert data["response"] == "json answer"
+            assert "model" in data
+
+
+class TestAskNoTools:
+    def test_no_tools_flag(self) -> None:
+        """--no-tools passes empty registry."""
+        conv = _make_conv("no tools")
+
+        captured_registry = None
+
+        async def mock_run_agent(
+            prompt: str, cfg: object, console: object, **kwargs: object
+        ) -> Conversation:
+            nonlocal captured_registry
+            captured_registry = kwargs.get("registry")
+            return conv
+
+        with (
+            patch("mita.cli.sys") as mock_sys,
+            patch("mita.agent.loop.run_agent", side_effect=mock_run_agent),
+            patch("mita.models.server.ensure_server", return_value=True),
+            patch("mita.models.server.ensure_model", return_value=True),
+        ):
+            mock_sys.stdin.isatty.return_value = True
+            mock_sys.stdout.isatty.return_value = True
+            result = runner.invoke(app, ["ask", "hello", "--no-tools", "--output", "text"])
+            assert result.exit_code == 0
+            assert captured_registry is not None
+            assert len(captured_registry.tool_names) == 0

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,121 @@
+"""Tests for the mita doctor command."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from mita.cli import app
+
+runner = CliRunner()
+
+
+class TestDoctorCommand:
+    def test_doctor_runs(self) -> None:
+        """Doctor command exits without error."""
+        with (
+            patch(
+                "mita.models.server.find_ollama_binary",
+                return_value="/usr/local/bin/ollama",
+            ),
+            patch("mita.models.server.is_server_running", return_value=False),
+            patch("mita.memory.discovery.discover_memory_files", return_value=[]),
+            patch("mita.index.store.IndexStore.exists", return_value=False),
+        ):
+            result = runner.invoke(app, ["doctor"])
+            assert result.exit_code == 0
+            assert "Python" in result.output
+
+    def test_doctor_shows_python_version(self) -> None:
+        """Doctor reports the current Python version."""
+        with (
+            patch("mita.models.server.find_ollama_binary", return_value=None),
+            patch("mita.models.server.is_server_running", return_value=False),
+            patch("mita.memory.discovery.discover_memory_files", return_value=[]),
+            patch("mita.index.store.IndexStore.exists", return_value=False),
+        ):
+            result = runner.invoke(app, ["doctor"])
+            assert result.exit_code == 0
+            assert "Python" in result.output
+
+    def test_doctor_ollama_not_found(self) -> None:
+        """Doctor shows error when Ollama binary is missing."""
+        with (
+            patch("mita.models.server.find_ollama_binary", return_value=None),
+            patch("mita.models.server.is_server_running", return_value=False),
+            patch("mita.memory.discovery.discover_memory_files", return_value=[]),
+            patch("mita.index.store.IndexStore.exists", return_value=False),
+        ):
+            result = runner.invoke(app, ["doctor"])
+            assert result.exit_code == 0
+            assert "not found" in result.output or "not installed" in result.output
+
+    def test_doctor_ollama_found(self) -> None:
+        """Doctor shows success when Ollama binary is present."""
+        with (
+            patch(
+                "mita.models.server.find_ollama_binary",
+                return_value="/usr/bin/ollama",
+            ),
+            patch("mita.models.server.is_server_running", return_value=False),
+            patch("mita.memory.discovery.discover_memory_files", return_value=[]),
+            patch("mita.index.store.IndexStore.exists", return_value=False),
+        ):
+            result = runner.invoke(app, ["doctor"])
+            assert result.exit_code == 0
+            assert "Ollama binary found" in result.output
+
+    def test_doctor_server_running(self) -> None:
+        """Doctor shows Ollama server running when it is."""
+        mock_client = MagicMock()
+        mock_client.list_models.return_value = []
+
+        with (
+            patch(
+                "mita.models.server.find_ollama_binary",
+                return_value="/usr/bin/ollama",
+            ),
+            patch("mita.models.server.is_server_running", return_value=True),
+            patch("mita.memory.discovery.discover_memory_files", return_value=[]),
+            patch(
+                "mita.models.ollama_client.OllamaClient",
+                return_value=mock_client,
+            ),
+            patch("mita.index.store.IndexStore.exists", return_value=False),
+        ):
+            result = runner.invoke(app, ["doctor"])
+            assert result.exit_code == 0
+            assert "server running" in result.output
+
+    def test_doctor_server_not_running(self) -> None:
+        """Doctor shows suggestion when Ollama is not running."""
+        with (
+            patch(
+                "mita.models.server.find_ollama_binary",
+                return_value="/usr/bin/ollama",
+            ),
+            patch("mita.models.server.is_server_running", return_value=False),
+            patch("mita.memory.discovery.discover_memory_files", return_value=[]),
+            patch("mita.index.store.IndexStore.exists", return_value=False),
+        ):
+            result = runner.invoke(app, ["doctor"])
+            assert result.exit_code == 0
+            assert "not running" in result.output
+
+    def test_doctor_memory_found(self) -> None:
+        """Doctor reports when memory files are found."""
+        from pathlib import Path
+
+        with (
+            patch("mita.models.server.find_ollama_binary", return_value=None),
+            patch("mita.models.server.is_server_running", return_value=False),
+            patch(
+                "mita.memory.discovery.discover_memory_files",
+                return_value=[Path("/tmp/MITA.md")],
+            ),
+            patch("mita.index.store.IndexStore.exists", return_value=False),
+        ):
+            result = runner.invoke(app, ["doctor"])
+            assert result.exit_code == 0
+            assert "Memory files found" in result.output

--- a/tests/test_plugins/test_client.py
+++ b/tests/test_plugins/test_client.py
@@ -36,29 +36,26 @@ class TestMCPPluginClient:
         assert client.transport == "stdio"
         assert not client.connected
 
-    def test_missing_command_raises(self) -> None:
+    @pytest.mark.asyncio
+    async def test_missing_command_raises(self) -> None:
         plugin = PluginDefinition(name="bad", transport="stdio")
         client = MCPPluginClient(plugin)
         with pytest.raises(ValueError, match="requires a command"):
-            import asyncio
+            await client.connect()
 
-            asyncio.get_event_loop().run_until_complete(client.connect())
-
-    def test_missing_url_raises(self) -> None:
+    @pytest.mark.asyncio
+    async def test_missing_url_raises(self) -> None:
         plugin = PluginDefinition(name="bad", transport="sse")
         client = MCPPluginClient(plugin)
         with pytest.raises(ValueError, match="requires a url"):
-            import asyncio
+            await client.connect()
 
-            asyncio.get_event_loop().run_until_complete(client.connect())
-
-    def test_unsupported_transport_raises(self) -> None:
+    @pytest.mark.asyncio
+    async def test_unsupported_transport_raises(self) -> None:
         plugin = PluginDefinition(name="bad", transport="grpc")
         client = MCPPluginClient(plugin)
         with pytest.raises(ValueError, match="Unsupported transport"):
-            import asyncio
-
-            asyncio.get_event_loop().run_until_complete(client.connect())
+            await client.connect()
 
     @pytest.mark.asyncio
     async def test_list_tools_not_connected(self, stdio_plugin: PluginDefinition) -> None:


### PR DESCRIPTION
## Summary
- Add stdin piping support for `mita ask` (`echo "prompt" | mita ask`)
- Add `--output` flag with rich/text/json formats and auto-detection for non-TTY stdout
- Add `--no-tools` flag to disable tool execution in both `chat` and `ask` commands
- Add `mita doctor` diagnostics command checking Python, Ollama, models, config, memory, and index
- Add KeyboardInterrupt handling in agent loop and REPL for graceful Ctrl-C
- Add `display_error_with_suggestion` helper for actionable error messages
- Fix pre-existing async event loop test failures in test_plugins/test_client.py

## Test plan
- [x] Verify `echo "what is 2+2" | mita ask --no-tools` outputs answer to stdout
- [x] Verify `mita ask "explain main.py" --output json` returns structured JSON
- [ ] Verify `mita doctor` reports system health with actionable suggestions
- [ ] Verify Ctrl-C during LLM call cancels gracefully without stack trace
- [ ] Verify `--no-tools` disables tool schemas and plugin loading
- [x] Run `poetry run pytest tests/ -v` — 429 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)