### PR TITLE
Fix security and concurrency bugs (#23, #26, #29, #34)

### DIFF
--- a/src/mita/cli.py
+++ b/src/mita/cli.py
@@ -618,7 +618,7 @@ def chat_command(
         if cfg.plugins and not no_tools:
             plugin_mgr = PluginManager(cfg.plugins)
             await plugin_mgr.start_all(console=chat_console)
-            await plugin_mgr.register_tools_async(registry)
+            await plugin_mgr.register_tools(registry)
 
         try:
 
@@ -718,7 +718,7 @@ def ask_command(
         if cfg.plugins and not no_tools:
             plugin_mgr = PluginManager(cfg.plugins)
             await plugin_mgr.start_all(console=ask_console)
-            await plugin_mgr.register_tools_async(registry)
+            await plugin_mgr.register_tools(registry)
 
         try:
             return await run_agent(full_prompt, cfg, ask_console, registry=registry)

--- a/src/mita/hooks/runner.py
+++ b/src/mita/hooks/runner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import fnmatch
+import shlex
 import subprocess
 from typing import Any
 
@@ -47,13 +48,16 @@ def _matches(hook: HookDefinition, context: dict[str, Any] | None) -> bool:
 
 
 def _render_command(command: str, context: dict[str, Any] | None) -> str:
-    """Substitute context variables into a hook command string."""
+    """Substitute context variables into a hook command string.
+
+    Context values are shell-escaped to prevent injection attacks.
+    """
     if context is None:
         return command
 
     rendered = command
     for key, value in context.items():
-        rendered = rendered.replace(f"{{{key}}}", str(value))
+        rendered = rendered.replace(f"{{{key}}}", shlex.quote(str(value)))
     return rendered
 
 
@@ -112,16 +116,25 @@ async def run_hooks(
 async def _execute_hook(command: str, timeout: float = HOOK_TIMEOUT) -> dict[str, Any]:
     """Execute a single hook command asynchronously."""
     try:
+        argv = shlex.split(command)
+    except ValueError as e:
+        return {
+            "command": command,
+            "returncode": -1,
+            "stdout": "",
+            "stderr": f"Invalid hook command syntax: {e}",
+        }
+
+    try:
         result = await asyncio.wait_for(
             asyncio.to_thread(
                 subprocess.run,
-                command,
-                shell=True,
+                argv,
+                shell=False,
                 capture_output=True,
                 text=True,
-                timeout=timeout,
             ),
-            timeout=timeout + 5,  # extra buffer for asyncio
+            timeout=timeout,
         )
         return {
             "command": command,

--- a/src/mita/index/store.py
+++ b/src/mita/index/store.py
@@ -51,8 +51,10 @@ class IndexStore:
         def _sync() -> None:
             db = self._connect()
             records = _chunks_to_records(chunks)
-            if self.TABLE_NAME in db.table_names():
+            try:
                 db.drop_table(self.TABLE_NAME)
+            except (ValueError, FileNotFoundError):
+                pass  # Table doesn't exist — that's fine
             db.create_table(self.TABLE_NAME, data=records)
 
         await asyncio.to_thread(_sync)

--- a/src/mita/plugins/manager.py
+++ b/src/mita/plugins/manager.py
@@ -110,38 +110,11 @@ class PluginManager:
                 result[pname] = []
         return result
 
-    def register_tools(self, registry: ToolRegistry) -> int:
+    async def register_tools(self, registry: ToolRegistry) -> int:
         """Register all MCP plugin tools into a ToolRegistry.
 
         Must be called after start_all(). Returns the number of tools registered.
         """
-        import asyncio
-
-        loop = asyncio.get_event_loop()
-        count = 0
-
-        for pname, client in self._clients.items():
-            try:
-                tools = loop.run_until_complete(client.list_tools())
-            except (ConnectionError, OSError, RuntimeError):
-                continue
-
-            for tool in tools:
-                tool_name = f"mcp:{pname}/{tool['name']}"
-                definition = ToolDefinition(
-                    name=tool_name,
-                    description=tool["description"],
-                    parameters=_schema_to_parameters(tool.get("inputSchema", {})),
-                    source=f"mcp:{pname}",
-                )
-                handler = _make_mcp_handler(client, tool["name"])
-                registry.register(definition, handler)
-                count += 1
-
-        return count
-
-    async def register_tools_async(self, registry: ToolRegistry) -> int:
-        """Async version of register_tools. Returns the number of tools registered."""
         count = 0
 
         for pname, client in self._clients.items():

--- a/tests/test_hooks/test_runner.py
+++ b/tests/test_hooks/test_runner.py
@@ -61,6 +61,16 @@ class TestRenderCommand:
         result = _render_command("echo {unknown}", {"file_path": "test.py"})
         assert result == "echo {unknown}"
 
+    def test_shell_injection_escaped(self) -> None:
+        result = _render_command("echo {file_path}", {"file_path": '"; rm -rf /'})
+        assert "rm -rf" not in result or "'" in result
+        # The malicious payload should be safely quoted
+        assert result.startswith("echo ")
+
+    def test_spaces_in_path_quoted(self) -> None:
+        result = _render_command("echo {file_path}", {"file_path": "path with spaces/file.py"})
+        assert "'path with spaces/file.py'" in result
+
 
 class TestRunHooks:
     @pytest.mark.asyncio

--- a/tests/test_plugins/test_manager.py
+++ b/tests/test_plugins/test_manager.py
@@ -147,7 +147,7 @@ class TestPluginManager:
         assert "web" not in result
 
     @pytest.mark.asyncio
-    async def test_register_tools_async(self) -> None:
+    async def test_register_tools(self) -> None:
         mgr = PluginManager([])
         mock_client = AsyncMock()
         mock_client.list_tools = AsyncMock(
@@ -166,7 +166,7 @@ class TestPluginManager:
         mgr._clients["fs"] = mock_client
 
         registry = ToolRegistry()
-        count = await mgr.register_tools_async(registry)
+        count = await mgr.register_tools(registry)
 
         assert count == 1
         assert registry.has_tool("mcp:fs/read_file")
@@ -257,7 +257,7 @@ class TestPluginManager:
         mgr._clients["greeter"] = mock_client
 
         registry = ToolRegistry()
-        await mgr.register_tools_async(registry)
+        await mgr.register_tools(registry)
 
         from mita.tools.schema import ToolCall
 


### PR DESCRIPTION
## Summary
- **#23 Shell injection in hook runner**: Context values are now escaped with `shlex.quote()` and hooks execute with `shell=False` via `shlex.split()`, preventing arbitrary command execution via malicious filenames
- **#29 TOCTOU race in index store**: Replaced check-then-act (`if table exists: drop`) with unconditional `drop_table()` wrapped in try/except
- **#34 Subprocess timeout race**: Removed redundant `subprocess.run(timeout=...)`, using `asyncio.wait_for()` as the sole timeout mechanism
- **#26 Sync `register_tools()` deadlock risk**: Removed the sync method using `loop.run_until_complete()`; consolidated into the async `register_tools()` method

## Test plan
- [x] All 431 existing tests pass
- [x] New tests for shell injection escaping and quoted paths
- [x] `invoke check` passes (format, lint, typecheck, test)

Closes #23, closes #26, closes #29, closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)