### PR TITLE
Fix remaining bug issues (#24, #25, #27, #31, #32, #35, #37, #38, #41)

### DIFF
--- a/src/mita/agent/loop.py
+++ b/src/mita/agent/loop.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
+import logging
 import re
 import time
 import uuid
+from dataclasses import dataclass, field
 from typing import Any
 
 from rich.console import Console
@@ -28,6 +31,8 @@ from mita.ui.display import (
     prompt_user_confirm,
 )
 from mita.ui.spinner import thinking_spinner
+
+_logger = logging.getLogger(__name__)
 
 MAX_ITERATIONS = 25
 _RAG_CONTEXT_PREFIX = "Relevant code from the project index:"
@@ -89,7 +94,7 @@ async def run_agent(
                         )
                     )
         except (ConnectionError, FileNotFoundError, ImportError, OSError):
-            pass  # Index unavailable; proceed without RAG
+            _logger.warning("RAG index unavailable, proceeding without it", exc_info=True)
 
     # Fire session_start hooks
     if config.hooks:
@@ -207,13 +212,14 @@ async def run_agent(
     return conversation
 
 
+@dataclass
 class _ResponseStats:
     """Token usage and timing stats from an LLM response."""
 
     prompt_tokens: int = 0
     completion_tokens: int = 0
     total_time: float = 0.0
-    ttft: float | None = None
+    ttft: float | None = field(default=None)
 
 
 async def _stream_response(
@@ -233,33 +239,33 @@ async def _stream_response(
     stats = _ResponseStats()
     start_time = time.monotonic()
 
-    # Show spinner while waiting for first token
-    spinner_ctx = thinking_spinner(console)
-    spinner_ctx.__enter__()
+    # Show spinner while waiting for first token; use ExitStack for safe cleanup
+    spinner_stack = contextlib.ExitStack()
+    spinner_stack.enter_context(thinking_spinner(console))
 
-    async for chunk in client.stream_chat(messages, tools=tool_schemas):
-        if first_token:
-            spinner_ctx.__exit__(None, None, None)
-            stats.ttft = time.monotonic() - start_time
-            first_token = False
+    try:
+        async for chunk in client.stream_chat(messages, tools=tool_schemas):
+            if first_token:
+                spinner_stack.close()
+                stats.ttft = time.monotonic() - start_time
+                first_token = False
 
-        delta = _extract_delta(chunk)
-        if delta:
-            full_text += delta
-            display_streaming_token(console, delta)
+            delta = _extract_delta(chunk)
+            if delta:
+                full_text += delta
+                display_streaming_token(console, delta)
 
-        # Accumulate tool call deltas
-        _accumulate_tool_call_deltas(chunk, tool_calls_by_index)
+            # Accumulate tool call deltas
+            _accumulate_tool_call_deltas(chunk, tool_calls_by_index)
 
-        # Extract usage from final chunk (LiteLLM includes it on the last chunk)
-        usage = _extract_usage(chunk)
-        if usage:
-            stats.prompt_tokens = usage.get("prompt_tokens", 0)
-            stats.completion_tokens = usage.get("completion_tokens", 0)
-
-    # Clean up spinner if no chunks arrived at all
-    if first_token:
-        spinner_ctx.__exit__(None, None, None)
+            # Extract usage from final chunk (LiteLLM includes it on the last chunk)
+            usage = _extract_usage(chunk)
+            if usage:
+                stats.prompt_tokens = usage.get("prompt_tokens", 0)
+                stats.completion_tokens = usage.get("completion_tokens", 0)
+    finally:
+        # Ensure spinner is cleaned up even on exception or empty stream
+        spinner_stack.close()
 
     stats.total_time = time.monotonic() - start_time
 

--- a/src/mita/cli.py
+++ b/src/mita/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import enum
+import shlex
 import sys
 from io import StringIO
 from typing import Annotated
@@ -434,8 +435,8 @@ def plugins_add(
     # Build TOML block
     lines = [f'\n[[plugins]]\nname = "{name}"\ntransport = "{transport}"']
     if command:
-        # Split command into executable + args
-        parts = command.split()
+        # Split command into executable + args (respects quoted arguments)
+        parts = shlex.split(command)
         lines.append(f'command = "{parts[0]}"')
         if len(parts) > 1:
             args_toml = ", ".join(f'"{a}"' for a in parts[1:])

--- a/src/mita/config/defaults.py
+++ b/src/mita/config/defaults.py
@@ -33,7 +33,7 @@ def _find_project_root(start: Path) -> Path | None:
     """Walk up from start to find a project root (contains .git or .mita)."""
     current = start.resolve()
     while True:
-        if (current / ".git").exists() or (current / PROJECT_CONFIG_DIR).exists():
+        if (current / ".git").is_dir() or (current / PROJECT_CONFIG_DIR).is_dir():
             return current
         parent = current.parent
         if parent == current:

--- a/src/mita/index/embeddings.py
+++ b/src/mita/index/embeddings.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 import ollama
 
 from mita.config.schema import MitaConfig
@@ -45,5 +47,6 @@ class EmbeddingClient:
                 m == self._model or (m is not None and m.startswith(base_name + ":"))
                 for m in model_names
             )
-        except Exception:  # noqa: BLE001
+        except (ollama.ResponseError, ConnectionError, OSError) as e:
+            logging.getLogger(__name__).warning("Embedding model check failed: %s", e)
             return False

--- a/src/mita/index/parser.py
+++ b/src/mita/index/parser.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any
@@ -168,6 +169,9 @@ def _parse_with_treesitter(
     try:
         parser = get_parser(language)  # type: ignore[arg-type]
     except Exception:  # noqa: BLE001
+        logging.getLogger(__name__).warning(
+            "Tree-sitter parser unavailable for language '%s'", language
+        )
         return []
 
     tree = parser.parse(content.encode("utf-8"))

--- a/src/mita/index/store.py
+++ b/src/mita/index/store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import shutil
 from pathlib import Path
 from typing import Any
@@ -122,6 +123,9 @@ class IndexStore:
             db = self._connect()
             return self.TABLE_NAME in db.table_names()
         except Exception:  # noqa: BLE001
+            logging.getLogger(__name__).warning(
+                "Index existence check failed for %s", self._db_path, exc_info=True
+            )
             return False
 
 

--- a/src/mita/skills/executor.py
+++ b/src/mita/skills/executor.py
@@ -75,10 +75,19 @@ def _tokenize(text: str) -> list[str]:
 
 
 def _substitute(template: str, args: dict[str, str]) -> str:
-    """Replace {{arg}} placeholders in the template."""
+    """Replace {{arg}} placeholders in the template.
+
+    Raises:
+        ValueError: If any placeholder has no matching argument.
+    """
+    # Find all placeholders first to validate
+    placeholders = re.findall(r"\{\{(\w+)\}\}", template)
+    missing = [p.strip() for p in placeholders if p.strip() not in args]
+    if missing:
+        raise ValueError(f"Missing required skill arguments: {', '.join(sorted(set(missing)))}")
 
     def replacer(match: re.Match[str]) -> str:
         key = match.group(1).strip()
-        return args.get(key, match.group(0))
+        return args[key]
 
     return re.sub(r"\{\{(\w+)\}\}", replacer, template)

--- a/src/mita/tools/builtins/__init__.py
+++ b/src/mita/tools/builtins/__init__.py
@@ -16,8 +16,10 @@ from mita.tools.builtins.grep_tool import TOOL_DEF as GREP_DEF
 from mita.tools.builtins.grep_tool import execute as grep_execute
 from mita.tools.builtins.shell import TOOL_DEF as SHELL_DEF
 from mita.tools.builtins.shell import execute as shell_execute
+from mita.tools.registry import ToolHandler
+from mita.tools.schema import ToolDefinition
 
-BUILTIN_TOOLS: dict[str, tuple[object, object]] = {
+BUILTIN_TOOLS: dict[str, tuple[ToolDefinition, ToolHandler]] = {
     FILE_READ_DEF.name: (FILE_READ_DEF, file_read_execute),
     FILE_WRITE_DEF.name: (FILE_WRITE_DEF, file_write_execute),
     FILE_EDIT_DEF.name: (FILE_EDIT_DEF, file_edit_execute),

--- a/src/mita/tools/builtins/git.py
+++ b/src/mita/tools/builtins/git.py
@@ -80,7 +80,14 @@ async def execute(args: dict[str, Any]) -> ToolResult:
         )
         stdout_bytes, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=30)
     except TimeoutError:
-        proc.kill()
+        try:
+            proc.terminate()
+            await asyncio.sleep(0.5)
+            if proc.returncode is None:
+                proc.kill()
+            await proc.wait()
+        except (OSError, ProcessLookupError):
+            pass
         return ToolResult(
             tool_call_id="",
             success=False,

--- a/src/mita/tools/builtins/shell.py
+++ b/src/mita/tools/builtins/shell.py
@@ -49,7 +49,14 @@ async def execute(args: dict[str, Any]) -> ToolResult:
         )
         stdout_bytes, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=timeout)
     except TimeoutError:
-        proc.kill()
+        try:
+            proc.terminate()
+            await asyncio.sleep(0.5)
+            if proc.returncode is None:
+                proc.kill()
+            await proc.wait()
+        except (OSError, ProcessLookupError):
+            pass
         return ToolResult(
             tool_call_id="",
             success=False,

--- a/src/mita/tools/registry.py
+++ b/src/mita/tools/registry.py
@@ -65,5 +65,5 @@ def create_default_registry() -> ToolRegistry:
 
     registry = ToolRegistry()
     for _name, (definition, handler) in BUILTIN_TOOLS.items():
-        registry.register(definition, handler)  # type: ignore[arg-type]
+        registry.register(definition, handler)
     return registry

--- a/tests/test_skills/test_executor.py
+++ b/tests/test_skills/test_executor.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from mita.skills.executor import _parse_args, _substitute, _tokenize, render_skill
 from mita.skills.loader import Skill, SkillArg, SkillFrontmatter
 
@@ -49,8 +51,9 @@ class TestSubstitute:
     def test_basic(self) -> None:
         assert _substitute("Hello {{name}}!", {"name": "world"}) == "Hello world!"
 
-    def test_missing_key(self) -> None:
-        assert _substitute("Hello {{name}}!", {}) == "Hello {{name}}!"
+    def test_missing_key_raises(self) -> None:
+        with pytest.raises(ValueError, match="Missing required skill arguments: name"):
+            _substitute("Hello {{name}}!", {})
 
     def test_multiple(self) -> None:
         result = _substitute("{{a}} and {{b}}", {"a": "X", "b": "Y"})


### PR DESCRIPTION
## Summary
- **#24** — Add `@dataclass` decorator to `_ResponseStats` preventing `AttributeError` on field access
- **#25** — Replace manual `__enter__`/`__exit__` spinner calls with `contextlib.ExitStack` for exception-safe cleanup
- **#27** — Add `logging.warning()` at 4 silent exception catch sites across agent loop, embeddings, parser, and index store; narrow `Exception` to specific types where possible
- **#31** — Fix `BUILTIN_TOOLS` type from `dict[str, tuple[object, object]]` to `dict[str, tuple[ToolDefinition, ToolHandler]]`; remove `type: ignore` in registry
- **#32** — Use `shlex.split()` instead of `str.split()` for plugin command parsing to handle quoted arguments
- **#35** — Use `.is_dir()` instead of `.exists()` in project root detection to avoid matching `.git` files in worktrees/submodules
- **#37** — Validate all `{{placeholder}}` patterns have matching args before rendering; raise `ValueError` for missing required args
- **#38** — Graceful process cleanup on timeout: `terminate()` → short wait → `kill()` → `wait()` with error handling
- **#41** — Issues URL already correct in pyproject.toml (no change needed)

## Test plan
- [x] All 431 tests pass
- [x] Updated `test_missing_key` → `test_missing_key_raises` for new validation behavior
- [x] `invoke check` passes (isort, format, lint, typecheck, test)

Closes #24, closes #25, closes #27, closes #31, closes #32, closes #35, closes #37, closes #38, closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)