### PR TITLE
fix: resolve critical and high severity issues from code review

### DIFF
--- a/src/mita/agent/loop.py
+++ b/src/mita/agent/loop.py
@@ -110,7 +110,8 @@ async def run_agent(
     last_tool_signature: str | None = None
     repeat_count = 0
     max_iterations = config.max_iterations
-    for iteration in range(max_iterations):
+    assistant_text = ""
+    for _iteration in range(max_iterations):
         try:
             # Truncate to fit context window
             conversation.truncate_to_fit(config.model.context_window)
@@ -198,9 +199,18 @@ async def run_agent(
         except KeyboardInterrupt:
             display_error(console, "[Interrupted]")
             # Add any partial response as assistant message
-            partial = locals().get("assistant_text", "")
-            if partial:
-                conversation.add(Message(role=Role.ASSISTANT, content=str(partial)))
+            if assistant_text:
+                conversation.add(Message(role=Role.ASSISTANT, content=assistant_text))
+            break
+        except (ConnectionError, TimeoutError, OSError) as e:
+            _logger.warning("LLM call failed: %s", e, exc_info=True)
+            display_error(console, f"LLM error: {e}")
+            if assistant_text:
+                conversation.add(Message(role=Role.ASSISTANT, content=assistant_text))
+            break
+        except json.JSONDecodeError as e:
+            _logger.warning("Failed to parse LLM response: %s", e, exc_info=True)
+            display_error(console, f"Response parse error: {e}")
             break
     else:
         display_error(

--- a/src/mita/cli.py
+++ b/src/mita/cli.py
@@ -452,17 +452,18 @@ def plugins_add(
         project_path.touch()
 
     transport = "stdio" if command else "sse"
-    # Build TOML block
-    lines = [f'\n[[plugins]]\nname = "{name}"\ntransport = "{transport}"']
+    # Build TOML block with proper escaping
+    esc = _escape_toml_string
+    lines = [f'\n[[plugins]]\nname = "{esc(name)}"\ntransport = "{esc(transport)}"']
     if command:
         # Split command into executable + args (respects quoted arguments)
         parts = shlex.split(command)
-        lines.append(f'command = "{parts[0]}"')
+        lines.append(f'command = "{esc(parts[0])}"')
         if len(parts) > 1:
-            args_toml = ", ".join(f'"{a}"' for a in parts[1:])
+            args_toml = ", ".join(f'"{esc(a)}"' for a in parts[1:])
             lines.append(f"args = [{args_toml}]")
     if url:
-        lines.append(f'url = "{url}"')
+        lines.append(f'url = "{esc(url)}"')
 
     block = "\n".join(lines) + "\n"
 
@@ -938,12 +939,22 @@ def _dict_to_toml(data: dict, lines: list[str], prefix: str) -> None:  # type: i
         _dict_to_toml(v, lines, prefix=f"{section}.")
 
 
+def _escape_toml_string(s: str) -> str:
+    """Escape a string for safe inclusion in a TOML quoted value."""
+    s = s.replace("\\", "\\\\")
+    s = s.replace('"', '\\"')
+    s = s.replace("\n", "\\n")
+    s = s.replace("\r", "\\r")
+    s = s.replace("\t", "\\t")
+    return s
+
+
 def _toml_value(v: object) -> str:
     """Format a Python value as a TOML value string."""
     if isinstance(v, bool):
         return "true" if v else "false"
     if isinstance(v, str):
-        return f'"{v}"'
+        return f'"{_escape_toml_string(v)}"'
     if isinstance(v, (int, float)):
         return str(v)
     if isinstance(v, list):

--- a/src/mita/hooks/manager.py
+++ b/src/mita/hooks/manager.py
@@ -49,9 +49,12 @@ def add_hook(event: str, command: str, match: str | None = None) -> None:
         project_path = config_dir / PROJECT_CONFIG_FILE
         project_path.touch()
 
-    lines = [f'\n[[hooks]]\nevent = "{event}"\ncommand = "{command}"']
+    from mita.cli import _escape_toml_string
+
+    esc = _escape_toml_string
+    lines = [f'\n[[hooks]]\nevent = "{esc(event)}"\ncommand = "{esc(command)}"']
     if match:
-        lines.append(f'match = "{match}"')
+        lines.append(f'match = "{esc(match)}"')
 
     block = "\n".join(lines) + "\n"
 

--- a/src/mita/index/manager.py
+++ b/src/mita/index/manager.py
@@ -86,9 +86,7 @@ async def build_index(force: bool = False, pull_model_fn: object | None = None) 
             try:
                 batch_embeddings = await embedder.embed_texts(batch)
             except (ConnectionError, TimeoutError, OSError) as e:
-                console.print(
-                    f"\n[red]Embedding failed at batch {i // batch_size + 1}: {e}[/red]"
-                )
+                console.print(f"\n[red]Embedding failed at batch {i // batch_size + 1}: {e}[/red]")
                 console.print("[red]Index build aborted to prevent data corruption.[/red]")
                 return
             embeddings.extend(batch_embeddings)

--- a/src/mita/index/manager.py
+++ b/src/mita/index/manager.py
@@ -79,13 +79,28 @@ async def build_index(force: bool = False, pull_model_fn: object | None = None) 
         console=console,
     ) as progress:
         task = progress.add_task("Generating embeddings...", total=len(texts))
-        embeddings = []
+        embeddings: list[list[float]] = []
         batch_size = 32
         for i in range(0, len(texts), batch_size):
             batch = texts[i : i + batch_size]
-            batch_embeddings = await embedder.embed_texts(batch)
+            try:
+                batch_embeddings = await embedder.embed_texts(batch)
+            except (ConnectionError, TimeoutError, OSError) as e:
+                console.print(
+                    f"\n[red]Embedding failed at batch {i // batch_size + 1}: {e}[/red]"
+                )
+                console.print("[red]Index build aborted to prevent data corruption.[/red]")
+                return
             embeddings.extend(batch_embeddings)
             progress.update(task, completed=min(i + batch_size, len(texts)))
+
+    # Verify alignment before attaching
+    if len(embeddings) != len(chunks):
+        console.print(
+            f"[red]Embedding count mismatch ({len(embeddings)} vs {len(chunks)} chunks). "
+            "Index build aborted.[/red]"
+        )
+        return
 
     # Attach embeddings to chunks
     for chunk, embedding in zip(chunks, embeddings):

--- a/src/mita/llm/streaming.py
+++ b/src/mita/llm/streaming.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from typing import Any
 
 from mita.llm.client import LLMClient
+
+_logger = logging.getLogger(__name__)
 
 
 async def stream_to_terminal(
@@ -29,15 +32,22 @@ async def stream_to_terminal(
     """
     full_text = ""
 
-    async for chunk in client.stream_chat(messages, tools=tools):
-        delta = _extract_delta_content(chunk)
-        if delta:
-            full_text += delta
-            if on_token:
-                on_token(delta)
-
-    if on_complete:
-        on_complete(full_text)
+    try:
+        async for chunk in client.stream_chat(messages, tools=tools):
+            delta = _extract_delta_content(chunk)
+            if delta:
+                full_text += delta
+                if on_token:
+                    try:
+                        on_token(delta)
+                    except Exception:
+                        _logger.warning("on_token callback failed", exc_info=True)
+    finally:
+        if on_complete:
+            try:
+                on_complete(full_text)
+            except Exception:
+                _logger.warning("on_complete callback failed", exc_info=True)
 
     return full_text
 

--- a/src/mita/memory/loader.py
+++ b/src/mita/memory/loader.py
@@ -24,7 +24,7 @@ def _classify_scope(path: Path) -> str:
 
 def _read_and_truncate(path: Path, max_lines: int) -> tuple[str, bool]:
     """Read a file and truncate to max_lines. Returns (content, was_truncated)."""
-    lines = path.read_text(encoding="utf-8").splitlines()
+    lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
     if len(lines) <= max_lines:
         return "\n".join(lines), False
     truncated = lines[:max_lines]

--- a/src/mita/plugins/client.py
+++ b/src/mita/plugins/client.py
@@ -43,16 +43,23 @@ class MCPPluginClient:
 
         self._exit_stack = AsyncExitStack()
 
-        if self._plugin.transport == "stdio":
-            await self._connect_stdio(timeout)
-        elif self._plugin.transport == "sse":
-            await self._connect_sse(timeout)
-        else:
-            raise ValueError(f"Unsupported transport: {self._plugin.transport}")
+        try:
+            if self._plugin.transport == "stdio":
+                await self._connect_stdio(timeout)
+            elif self._plugin.transport == "sse":
+                await self._connect_sse(timeout)
+            else:
+                raise ValueError(f"Unsupported transport: {self._plugin.transport}")
+        except Exception:
+            # Clean up resources on connection failure
+            await self._exit_stack.aclose()
+            self._exit_stack = None
+            raise
 
     async def _connect_stdio(self, timeout: float) -> None:
         """Connect via stdio transport (subprocess)."""
-        assert self._exit_stack is not None
+        if self._exit_stack is None:
+            raise RuntimeError("connect() must be called before _connect_stdio()")
 
         if not self._plugin.command:
             raise ValueError(f"Plugin '{self.name}' requires a command for stdio transport")
@@ -77,7 +84,8 @@ class MCPPluginClient:
 
     async def _connect_sse(self, timeout: float) -> None:
         """Connect via SSE transport (HTTP)."""
-        assert self._exit_stack is not None
+        if self._exit_stack is None:
+            raise RuntimeError("connect() must be called before _connect_sse()")
 
         if not self._plugin.url:
             raise ValueError(f"Plugin '{self.name}' requires a url for SSE transport")

--- a/src/mita/tools/builtins/file_edit.py
+++ b/src/mita/tools/builtins/file_edit.py
@@ -39,11 +39,17 @@ async def execute(args: dict[str, Any]) -> ToolResult:
 
     path = Path(path_str).expanduser().resolve()
 
+    from mita.tools.safety import validate_path_for_write
+
+    path_error = validate_path_for_write(path)
+    if path_error:
+        return ToolResult(tool_call_id="", success=False, error=path_error)
+
     if not path.is_file():
         return ToolResult(tool_call_id="", success=False, error=f"File not found: {path}")
 
     try:
-        content = path.read_text(encoding="utf-8")
+        content = path.read_text(encoding="utf-8", errors="replace")
     except OSError as e:
         return ToolResult(tool_call_id="", success=False, error=f"Cannot read file: {e}")
 

--- a/src/mita/tools/builtins/file_read.py
+++ b/src/mita/tools/builtins/file_read.py
@@ -31,16 +31,33 @@ TOOL_DEF = ToolDefinition(
 )
 
 
+def _safe_int(value: object, default: int, minimum: int = 1) -> int:
+    """Safely convert a value to int with bounds checking."""
+    if value is None:
+        return max(minimum, default)
+    try:
+        result = int(str(value))
+    except (ValueError, TypeError):
+        result = default
+    return max(minimum, result)
+
+
 async def execute(args: dict[str, Any]) -> ToolResult:
     """Read file contents with optional offset and limit."""
     path_str = str(args.get("path", ""))
-    offset = int(args.get("offset", 1) or 1)
-    limit = int(args.get("limit", 2000) or 2000)
+    offset = _safe_int(args.get("offset", 1), default=1)
+    limit = _safe_int(args.get("limit", 2000), default=2000)
 
     if not path_str:
         return ToolResult(tool_call_id="", success=False, error="Missing required parameter: path")
 
     path = Path(path_str).expanduser().resolve()
+
+    from mita.tools.safety import validate_path_for_read
+
+    path_error = validate_path_for_read(path)
+    if path_error:
+        return ToolResult(tool_call_id="", success=False, error=path_error)
 
     if not path.exists():
         return ToolResult(tool_call_id="", success=False, error=f"File not found: {path}")

--- a/src/mita/tools/builtins/file_write.py
+++ b/src/mita/tools/builtins/file_write.py
@@ -28,6 +28,12 @@ async def execute(args: dict[str, Any]) -> ToolResult:
 
     path = Path(path_str).expanduser().resolve()
 
+    from mita.tools.safety import validate_path_for_write
+
+    path_error = validate_path_for_write(path)
+    if path_error:
+        return ToolResult(tool_call_id="", success=False, error=path_error)
+
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         existed = path.exists()

--- a/src/mita/tools/builtins/glob_tool.py
+++ b/src/mita/tools/builtins/glob_tool.py
@@ -44,6 +44,12 @@ async def execute(args: dict[str, Any]) -> ToolResult:
     if not base.is_dir():
         return ToolResult(tool_call_id="", success=False, error=f"Not a directory: {base}")
 
+    from mita.tools.safety import validate_search_base
+
+    base_error = validate_search_base(base)
+    if base_error:
+        return ToolResult(tool_call_id="", success=False, error=base_error)
+
     try:
         matches = sorted(base.glob(pattern))
     except ValueError as e:

--- a/src/mita/tools/builtins/grep_tool.py
+++ b/src/mita/tools/builtins/grep_tool.py
@@ -55,6 +55,17 @@ async def execute(args: dict[str, Any]) -> ToolResult:
 
     target = Path(path_str).expanduser().resolve()
 
+    from mita.tools.safety import validate_path_for_read, validate_search_base
+
+    if target.is_file():
+        read_error = validate_path_for_read(target)
+        if read_error:
+            return ToolResult(tool_call_id="", success=False, error=read_error)
+    elif target.is_dir():
+        base_error = validate_search_base(target)
+        if base_error:
+            return ToolResult(tool_call_id="", success=False, error=base_error)
+
     if target.is_file():
         files = [target]
     elif target.is_dir():

--- a/src/mita/tools/builtins/shell.py
+++ b/src/mita/tools/builtins/shell.py
@@ -34,7 +34,10 @@ TOOL_DEF = ToolDefinition(
 async def execute(args: dict[str, Any]) -> ToolResult:
     """Execute a shell command."""
     command = str(args.get("command", ""))
-    timeout = int(args.get("timeout", 120) or 120)
+    try:
+        timeout = max(1, int(args.get("timeout", 120) or 120))
+    except (ValueError, TypeError):
+        timeout = 120
 
     if not command:
         return ToolResult(

--- a/src/mita/tools/safety.py
+++ b/src/mita/tools/safety.py
@@ -1,20 +1,35 @@
-"""Destructive action detection and banned command checking."""
+"""Destructive action detection, banned command checking, and path safety."""
 
 from __future__ import annotations
 
 import re
+import shlex
+from pathlib import Path
 
 from mita.config.schema import ToolSettings
 from mita.tools.schema import ToolCall, ToolDefinition
 
+# Paths that should never be read or written by tools
+SENSITIVE_PATH_PATTERNS: list[str] = [
+    ".ssh",
+    ".gnupg",
+    ".aws/credentials",
+    ".env",
+    ".netrc",
+]
+
 # Patterns that indicate destructive shell commands
 DESTRUCTIVE_PATTERNS: list[re.Pattern[str]] = [
-    re.compile(r"\brm\s+(-[a-zA-Z]*f|-[a-zA-Z]*r)", re.IGNORECASE),
-    re.compile(r"\bgit\s+(push\s+--force|reset\s+--hard|clean\s+-[a-zA-Z]*f)", re.IGNORECASE),
-    re.compile(r"\bchmod\s+-R\s+0?7", re.IGNORECASE),
-    re.compile(r"\bchown\s+-R\b", re.IGNORECASE),
+    re.compile(r"\brm\s+(-[a-zA-Z]*f|-[a-zA-Z]*r|--force|--recursive)", re.IGNORECASE),
+    re.compile(
+        r"\bgit\s+(push\s+(--force|-f\b)|reset\s+--hard|clean\s+(-[a-zA-Z]*f|--force))",
+        re.IGNORECASE,
+    ),
+    re.compile(r"\bchmod\s+(-R|--recursive)\s+0?7", re.IGNORECASE),
+    re.compile(r"\bchown\s+(-R|--recursive)\b", re.IGNORECASE),
     re.compile(r"\b(truncate|shred)\b", re.IGNORECASE),
     re.compile(r">\s*/dev/\w+", re.IGNORECASE),
+    re.compile(r"\bxargs\s+rm\b", re.IGNORECASE),
 ]
 
 # Git subcommands that are destructive and need confirmation
@@ -28,11 +43,27 @@ DESTRUCTIVE_GIT_PATTERNS: list[re.Pattern[str]] = [
 ]
 
 
+def _normalize_command(command: str) -> str:
+    """Normalize a command for comparison by tokenizing and rejoining."""
+    try:
+        tokens = shlex.split(command.strip())
+    except ValueError:
+        # If shlex can't parse it, fall back to whitespace normalization
+        tokens = command.strip().split()
+    return " ".join(tokens)
+
+
 def is_command_banned(command: str, banned_commands: list[str]) -> bool:
-    """Check if a shell command matches any banned command pattern."""
-    normalized = command.strip()
+    """Check if a shell command matches any banned command pattern.
+
+    Uses both substring matching on the raw command and token-normalized
+    matching for robustness against whitespace/quoting variations.
+    """
+    raw = command.strip()
+    normalized = _normalize_command(raw)
     for banned in banned_commands:
-        if banned in normalized:
+        banned_norm = _normalize_command(banned)
+        if banned in raw or banned_norm in normalized:
             return True
     return False
 
@@ -89,3 +120,83 @@ def needs_confirmation(
             return True
 
     return False
+
+
+# ── Path boundary checking ───────────────────────────────────────
+
+# Override for testing — set to a Path to bypass project root detection
+_workspace_root_override: Path | None = None
+
+
+def get_workspace_root() -> Path:
+    """Return the workspace root directory for path boundary checks.
+
+    Uses the project root (directory containing .git or .mita),
+    falling back to the current working directory.
+    """
+    if _workspace_root_override is not None:
+        return _workspace_root_override
+
+    from mita.config.defaults import _find_project_root
+
+    root = _find_project_root(Path.cwd())
+    return root if root is not None else Path.cwd()
+
+
+def _is_sensitive_path(resolved: Path) -> bool:
+    """Check if a resolved path matches known sensitive locations."""
+    path_str = str(resolved)
+    home = str(Path.home())
+    for pattern in SENSITIVE_PATH_PATTERNS:
+        sensitive = f"{home}/{pattern}"
+        if path_str == sensitive or path_str.startswith(f"{sensitive}/"):
+            return True
+    return False
+
+
+def validate_path_for_read(resolved: Path) -> str | None:
+    """Validate a resolved path is safe to read.
+
+    Returns an error message if blocked, or None if allowed.
+    Blocks access to known sensitive paths (SSH keys, credentials).
+    """
+    if _is_sensitive_path(resolved):
+        return f"Access denied: {resolved} is a sensitive file"
+    return None
+
+
+def validate_path_for_write(resolved: Path) -> str | None:
+    """Validate a resolved path is safe to write.
+
+    Returns an error message if blocked, or None if allowed.
+    Writes are restricted to the workspace root and its subdirectories.
+    """
+    if _is_sensitive_path(resolved):
+        return f"Access denied: {resolved} is a sensitive file"
+
+    workspace = get_workspace_root().resolve()
+    try:
+        resolved.relative_to(workspace)
+    except ValueError:
+        return (
+            f"Access denied: {resolved} is outside the workspace ({workspace}). "
+            "File writes are restricted to the project directory."
+        )
+    return None
+
+
+def validate_search_base(resolved: Path) -> str | None:
+    """Validate a resolved directory is safe as a glob/grep search base.
+
+    Returns an error message if blocked, or None if allowed.
+    Search bases are restricted to the workspace root and its subdirectories.
+    """
+    workspace = get_workspace_root().resolve()
+    try:
+        resolved.relative_to(workspace)
+    except ValueError:
+        return (
+            f"Access denied: {resolved} is outside the workspace ({workspace}). "
+            "Searches are restricted to the project directory."
+        )
+    return None

--- a/tests/test_tools/conftest.py
+++ b/tests/test_tools/conftest.py
@@ -1,0 +1,18 @@
+"""Fixtures for tool tests."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+import mita.tools.safety as safety_module
+
+
+@pytest.fixture(autouse=True)
+def _workspace_root_to_tmp(tmp_path: Path) -> Iterator[None]:
+    """Set the workspace root to tmp_path so file tools work with temp dirs."""
+    safety_module._workspace_root_override = tmp_path
+    yield
+    safety_module._workspace_root_override = None


### PR DESCRIPTION
## Summary

Fixes all 10 critical and high severity issues identified during the full codebase code review.

### Critical fixes
- **#46 TOML injection**: Added `_escape_toml_string()` helper that escapes `\`, `"`, `\n`, `\r`, `\t` in all TOML string generation (cli.py, hooks/manager.py)
- **#47 Path boundary checking**: Added workspace root validation for writes/edits/searches and sensitive path blocking (`.ssh`, `.gnupg`, `.aws/credentials`, `.env`, `.netrc`) for reads across all file tools
- **#48 Plugin resource leak**: Wrapped `MCPPluginClient.connect()` in try/except to ensure `AsyncExitStack.aclose()` on failure; replaced `assert` with `RuntimeError` checks
- **#49 Index corruption**: Added try/except around `embed_texts()` that aborts the build on failure; added embedding-to-chunk count alignment verification
- **#50 `locals().get()` bug**: Initialized `assistant_text = ""` before the agent loop; replaced unreliable `locals().get()` with direct variable access

### High severity fixes
- **#51 Command banning bypass**: Added `_normalize_command()` using `shlex.split` for token-based matching; extended `DESTRUCTIVE_PATTERNS` with `--force`, `--recursive` long-form flags and `xargs rm`
- **#52 Streaming callback failure**: Wrapped `on_token()` in try/except; moved `on_complete()` to `finally` block so it always fires
- **#53 Type coercion crashes**: Added `_safe_int()` helper with `ValueError`/`TypeError` handling and min-value clamping for file_read params; safe timeout parsing in shell tool
- **#54 Agent loop exceptions**: Added `except` clauses for `ConnectionError`, `TimeoutError`, `OSError`, and `json.JSONDecodeError` with logging and user-facing error messages
- **#55 Encoding inconsistency**: Added `errors="replace"` to `file_edit.py` and `memory/loader.py` to match `file_read.py` behavior

## Test plan

- [x] All 461 existing tests pass
- [x] ruff check clean
- [x] mypy strict clean
- [ ] Manual test: verify TOML escaping with special characters in plugin/hook names
- [ ] Manual test: verify file tools reject paths outside workspace
- [ ] Manual test: verify file tools reject sensitive paths like `~/.ssh/id_rsa`

🤖 Generated with [Claude Code](https://claude.com/claude-code)