### PR TITLE
feat: add permission modes, fix agent loop error handling, plumb config to tools

### DIFF
--- a/src/mita/agent/loop.py
+++ b/src/mita/agent/loop.py
@@ -56,6 +56,8 @@ async def run_agent(
         conversation: Existing conversation to continue, or None to start fresh.
         registry: Tool registry, or None to create default.
         llm_client: LLM client, or None to create from config.
+        session_approved: Tool names approved for the session (skip confirmation).
+            Not mutated by the agent loop — callers manage the set.
 
     Returns:
         The updated conversation.

--- a/src/mita/agent/loop.py
+++ b/src/mita/agent/loop.py
@@ -45,6 +45,7 @@ async def run_agent(
     conversation: Conversation | None = None,
     registry: ToolRegistry | None = None,
     llm_client: LLMClient | None = None,
+    session_approved: set[str] | None = None,
 ) -> Conversation:
     """Run the agent loop for a single user prompt.
 
@@ -191,7 +192,9 @@ async def run_agent(
                         tool_calls=tool_calls_raw,
                     )
                 )
-                await _process_tool_calls(tool_calls_raw, conversation, registry, config, console)
+                await _process_tool_calls(
+                    tool_calls_raw, conversation, registry, config, console, session_approved
+                )
                 continue
 
             # No tool calls — add assistant message and stop
@@ -213,6 +216,12 @@ async def run_agent(
         except json.JSONDecodeError as e:
             _logger.warning("Failed to parse LLM response: %s", e, exc_info=True)
             display_error(console, f"Response parse error: {e}")
+            break
+        except Exception as e:  # noqa: BLE001
+            _logger.error("Unexpected error in agent loop: %s", e, exc_info=True)
+            display_error(console, f"Unexpected error: {e}")
+            if assistant_text:
+                conversation.add(Message(role=Role.ASSISTANT, content=assistant_text))
             break
     else:
         display_error(
@@ -524,6 +533,7 @@ async def _process_tool_calls(
     registry: ToolRegistry,
     config: MitaConfig,
     console: Console,
+    session_approved: set[str] | None = None,
 ) -> None:
     """Process tool calls from an LLM response."""
     # Import hooks runner once if hooks are configured
@@ -568,7 +578,13 @@ async def _process_tool_calls(
             return await prompt_user_confirm(console, prompt)
 
         # Execute with safety checks
-        result = await execute_tool(tool_call, registry, config.tools, confirm_fn=confirm_fn)
+        result = await execute_tool(
+            tool_call,
+            registry,
+            config.tools,
+            confirm_fn=confirm_fn,
+            session_approved=session_approved,
+        )
 
         # Display result
         display_tool_result(console, result)

--- a/src/mita/cli.py
+++ b/src/mita/cli.py
@@ -589,6 +589,14 @@ def chat_command(
         bool,
         typer.Option("--no-tools", help="Disable all tools."),
     ] = False,
+    permission: Annotated[
+        str | None,
+        typer.Option(
+            "--permission",
+            "-p",
+            help="Permission mode: ask (default), auto_edit, or trust.",
+        ),
+    ] = None,
 ) -> None:
     """Open an interactive chat session with the agent."""
     import asyncio
@@ -596,12 +604,22 @@ def chat_command(
     from mita.agent.conversation import Conversation
     from mita.agent.loop import run_agent
     from mita.config.loader import load_config as _load_config
+    from mita.config.schema import PermissionMode
     from mita.models.server import ensure_model, ensure_server
     from mita.tools.registry import ToolRegistry, create_default_registry
     from mita.ui.display import get_console
     from mita.ui.repl import repl_loop
 
     cfg = _load_config()
+
+    if permission is not None:
+        try:
+            cfg.tools.permission_mode = PermissionMode(permission)
+        except ValueError:
+            console.print(f"[red]Invalid permission mode: {permission}[/red]")
+            console.print("Valid modes: ask, auto_edit, trust")
+            raise typer.Exit(1)
+
     chat_console = get_console()
 
     if not ensure_server(

--- a/src/mita/config/schema.py
+++ b/src/mita/config/schema.py
@@ -2,7 +2,38 @@
 
 from __future__ import annotations
 
+import enum
+
 from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+class PermissionMode(enum.StrEnum):
+    """Permission mode controlling which tools are auto-approved.
+
+    - ask: only read-only tools auto-approved (safest)
+    - auto_edit: file reads/writes/edits and git auto-approved, shell requires confirmation
+    - trust: all tools auto-approved (dangerous)
+    """
+
+    ASK = "ask"
+    AUTO_EDIT = "auto_edit"
+    TRUST = "trust"
+
+
+# Tools auto-approved in each permission mode
+PERMISSION_MODE_TOOLS: dict[PermissionMode, list[str]] = {
+    PermissionMode.ASK: ["file_read", "glob", "grep"],
+    PermissionMode.AUTO_EDIT: ["file_read", "glob", "grep", "file_write", "file_edit", "git"],
+    PermissionMode.TRUST: [
+        "file_read",
+        "glob",
+        "grep",
+        "file_write",
+        "file_edit",
+        "git",
+        "shell",
+    ],
+}
 
 
 class OllamaSettings(BaseModel):
@@ -79,7 +110,10 @@ class ModelSettings(BaseModel):
 class ToolSettings(BaseModel):
     """Tool execution settings."""
 
-    auto_approve: list[str] = Field(default_factory=lambda: ["file_read", "glob", "grep"])
+    permission_mode: PermissionMode = PermissionMode.ASK
+    auto_approve: list[str] = Field(
+        default_factory=lambda: list(PERMISSION_MODE_TOOLS[PermissionMode.ASK])
+    )
     confirm_destructive: bool = True
     shell_timeout: int = 120
     glob_max_results: int = 500
@@ -87,6 +121,15 @@ class ToolSettings(BaseModel):
     banned_commands: list[str] = Field(
         default_factory=lambda: ["rm -rf /", "mkfs", "dd if=/dev/zero"]
     )
+
+    @property
+    def effective_auto_approve(self) -> set[str]:
+        """Return the effective set of auto-approved tools.
+
+        Merges the permission mode's default tools with any explicit auto_approve overrides.
+        """
+        mode_tools = set(PERMISSION_MODE_TOOLS[self.permission_mode])
+        return mode_tools | set(self.auto_approve)
 
     @field_validator("shell_timeout")
     @classmethod

--- a/src/mita/tools/builtins/glob_tool.py
+++ b/src/mita/tools/builtins/glob_tool.py
@@ -27,13 +27,14 @@ TOOL_DEF = ToolDefinition(
     destructive=False,
 )
 
-MAX_RESULTS = 500
+DEFAULT_MAX_RESULTS = 500
 
 
 async def execute(args: dict[str, Any]) -> ToolResult:
     """Search for files matching a glob pattern."""
     pattern = str(args.get("pattern", ""))
     base_path = str(args.get("path", ".") or ".")
+    max_results = int(args.get("_max_results", DEFAULT_MAX_RESULTS))
 
     if not pattern:
         return ToolResult(
@@ -61,12 +62,12 @@ async def execute(args: dict[str, Any]) -> ToolResult:
     if not files:
         return ToolResult(tool_call_id="", success=True, output="No files matched.")
 
-    truncated = len(files) > MAX_RESULTS
-    output_files = files[:MAX_RESULTS]
+    truncated = len(files) > max_results
+    output_files = files[:max_results]
     output = "\n".join(output_files)
 
     if truncated:
-        output += f"\n\n... [{len(files)} total matches, showing first {MAX_RESULTS}]"
+        output += f"\n\n... [{len(files)} total matches, showing first {max_results}]"
     else:
         output += f"\n\n[{len(files)} file(s) matched]"
 

--- a/src/mita/tools/builtins/glob_tool.py
+++ b/src/mita/tools/builtins/glob_tool.py
@@ -34,7 +34,10 @@ async def execute(args: dict[str, Any]) -> ToolResult:
     """Search for files matching a glob pattern."""
     pattern = str(args.get("pattern", ""))
     base_path = str(args.get("path", ".") or ".")
-    max_results = int(args.get("_max_results", DEFAULT_MAX_RESULTS))
+    try:
+        max_results = max(1, int(args.get("_max_results", DEFAULT_MAX_RESULTS)))
+    except (TypeError, ValueError):
+        max_results = DEFAULT_MAX_RESULTS
 
     if not pattern:
         return ToolResult(

--- a/src/mita/tools/builtins/grep_tool.py
+++ b/src/mita/tools/builtins/grep_tool.py
@@ -42,7 +42,10 @@ async def execute(args: dict[str, Any]) -> ToolResult:
     pattern_str = str(args.get("pattern", ""))
     path_str = str(args.get("path", ".") or ".")
     include = args.get("include")
-    max_matches = int(args.get("_max_matches", DEFAULT_MAX_MATCHES))
+    try:
+        max_matches = max(1, int(args.get("_max_matches", DEFAULT_MAX_MATCHES)))
+    except (TypeError, ValueError):
+        max_matches = DEFAULT_MAX_MATCHES
 
     if not pattern_str:
         return ToolResult(

--- a/src/mita/tools/builtins/grep_tool.py
+++ b/src/mita/tools/builtins/grep_tool.py
@@ -34,7 +34,7 @@ TOOL_DEF = ToolDefinition(
     destructive=False,
 )
 
-MAX_MATCHES = 200
+DEFAULT_MAX_MATCHES = 200
 
 
 async def execute(args: dict[str, Any]) -> ToolResult:
@@ -42,6 +42,7 @@ async def execute(args: dict[str, Any]) -> ToolResult:
     pattern_str = str(args.get("pattern", ""))
     path_str = str(args.get("path", ".") or ".")
     include = args.get("include")
+    max_matches = int(args.get("_max_matches", DEFAULT_MAX_MATCHES))
 
     if not pattern_str:
         return ToolResult(
@@ -87,17 +88,17 @@ async def execute(args: dict[str, Any]) -> ToolResult:
             if regex.search(line):
                 matches.append(f"{file_path}:{line_num}: {line.rstrip()}")
                 match_count += 1
-                if match_count >= MAX_MATCHES:
+                if match_count >= max_matches:
                     break
-        if match_count >= MAX_MATCHES:
+        if match_count >= max_matches:
             break
 
     if not matches:
         return ToolResult(tool_call_id="", success=True, output="No matches found.")
 
     output = "\n".join(matches)
-    if match_count >= MAX_MATCHES:
-        output += f"\n\n... [showing first {MAX_MATCHES} matches]"
+    if match_count >= max_matches:
+        output += f"\n\n... [showing first {max_matches} matches]"
     else:
         output += f"\n\n[{match_count} match(es)]"
 

--- a/src/mita/tools/executor.py
+++ b/src/mita/tools/executor.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable, Coroutine
+from typing import Any
 
 from mita.config.schema import ToolSettings
 from mita.tools.registry import ToolRegistry
@@ -11,12 +13,15 @@ from mita.tools.schema import ToolCall, ToolResult
 
 _logger = logging.getLogger(__name__)
 
+ConfirmFn = Callable[[str], Coroutine[Any, Any, bool]]
+
 
 async def execute_tool(
     tool_call: ToolCall,
     registry: ToolRegistry,
     settings: ToolSettings,
-    confirm_fn: object | None = None,
+    confirm_fn: ConfirmFn | None = None,
+    session_approved: set[str] | None = None,
 ) -> ToolResult:
     """Execute a tool call with safety checks and optional confirmation.
 
@@ -26,6 +31,7 @@ async def execute_tool(
         settings: Tool settings (auto_approve, banned_commands, etc.).
         confirm_fn: Optional async callable(str) -> bool for user confirmation.
                      If None, destructive tools are denied automatically.
+        session_approved: Set of tool names approved for the current session.
     """
     tool_def = registry.get_definition(tool_call.name)
     if tool_def is None:
@@ -54,7 +60,7 @@ async def execute_tool(
             )
 
     # Confirmation flow
-    if needs_confirmation(tool_call, tool_def, settings):
+    if needs_confirmation(tool_call, tool_def, settings, session_approved=session_approved):
         if confirm_fn is None:
             return ToolResult(
                 tool_call_id=tool_call.id,
@@ -70,6 +76,11 @@ async def execute_tool(
                 success=False,
                 error="User denied this action.",
             )
+
+    if tool_call.name == "glob":
+        tool_call.arguments.setdefault("_max_results", settings.glob_max_results)
+    elif tool_call.name == "grep":
+        tool_call.arguments.setdefault("_max_matches", settings.grep_max_matches)
 
     return await registry.execute(tool_call)
 

--- a/src/mita/tools/executor.py
+++ b/src/mita/tools/executor.py
@@ -78,9 +78,9 @@ async def execute_tool(
             )
 
     if tool_call.name == "glob":
-        tool_call.arguments.setdefault("_max_results", settings.glob_max_results)
+        tool_call.arguments["_max_results"] = settings.glob_max_results
     elif tool_call.name == "grep":
-        tool_call.arguments.setdefault("_max_matches", settings.grep_max_matches)
+        tool_call.arguments["_max_matches"] = settings.grep_max_matches
 
     return await registry.execute(tool_call)
 

--- a/src/mita/tools/executor.py
+++ b/src/mita/tools/executor.py
@@ -69,7 +69,7 @@ async def execute_tool(
             )
 
         prompt = f"Allow {tool_call.name}({_summarize_args(tool_call)})?"
-        approved = await confirm_fn(prompt)  # type: ignore[operator]
+        approved = await confirm_fn(prompt)
         if not approved:
             return ToolResult(
                 tool_call_id=tool_call.id,

--- a/src/mita/tools/safety.py
+++ b/src/mita/tools/safety.py
@@ -7,6 +7,7 @@ import shlex
 from pathlib import Path
 
 from mita.config.schema import ToolSettings
+from mita.tools.builtins.git import is_safe_git_command
 from mita.tools.schema import ToolCall, ToolDefinition
 
 # Paths that should never be read or written by tools
@@ -113,19 +114,24 @@ def needs_confirmation(
     tool_call: ToolCall,
     tool_def: ToolDefinition,
     settings: ToolSettings,
+    session_approved: set[str] | None = None,
 ) -> bool:
     """Determine if a tool call needs user confirmation before execution.
 
     Returns True if:
     - The tool is marked destructive AND confirm_destructive is on
-      AND the tool is not in auto_approve.
+      AND the tool is not in the effective auto-approve set or session-approved set.
     - Or the tool is 'shell' and the command looks destructive.
-    - Or the tool is 'git' and the subcommand is destructive.
+    - Or the tool is 'git' and the subcommand is destructive (not read-only).
     """
     if not settings.confirm_destructive:
         return False
 
-    if tool_call.name in settings.auto_approve:
+    effective = settings.effective_auto_approve
+    if session_approved:
+        effective = effective | session_approved
+
+    if tool_call.name in effective:
         return False
 
     if tool_def.destructive:
@@ -138,6 +144,8 @@ def needs_confirmation(
 
     if tool_call.name == "git":
         subcommand = tool_call.arguments.get("subcommand", "")
+        if is_safe_git_command(subcommand):
+            return False
         if is_git_command_destructive(subcommand):
             return True
 

--- a/src/mita/tools/safety.py
+++ b/src/mita/tools/safety.py
@@ -144,10 +144,12 @@ def needs_confirmation(
 
     if tool_call.name == "git":
         subcommand = tool_call.arguments.get("subcommand", "")
-        if is_safe_git_command(subcommand):
-            return False
+        # Check destructive FIRST — `branch -D` starts with "branch" (a safe
+        # base subcommand) but is destructive due to the -D flag.
         if is_git_command_destructive(subcommand):
             return True
+        if is_safe_git_command(subcommand):
+            return False
 
     return False
 

--- a/tests/test_cli/test_commands.py
+++ b/tests/test_cli/test_commands.py
@@ -26,6 +26,18 @@ class TestVersionFlag:
         assert result.exit_code == 0
 
 
+class TestChatPermissionFlag:
+    def test_invalid_permission_mode(self) -> None:
+        result = runner.invoke(app, ["chat", "--permission", "yolo"])
+        assert result.exit_code != 0
+        assert "Invalid permission mode" in result.output
+
+    def test_chat_help_shows_permission_flag(self) -> None:
+        result = runner.invoke(app, ["chat", "--help"])
+        assert result.exit_code == 0
+        assert "--permission" in result.output
+
+
 # ── Config commands ──────────────────────────────────────────────
 
 

--- a/tests/test_cli/test_commands.py
+++ b/tests/test_cli/test_commands.py
@@ -35,7 +35,8 @@ class TestChatPermissionFlag:
     def test_chat_help_shows_permission_flag(self) -> None:
         result = runner.invoke(app, ["chat", "--help"])
         assert result.exit_code == 0
-        assert "--permission" in result.output
+        # Rich may insert ANSI codes between "--" and "permission", so check the word
+        assert "permission" in result.output.lower()
 
 
 # ── Config commands ──────────────────────────────────────────────

--- a/tests/test_config/test_schema.py
+++ b/tests/test_config/test_schema.py
@@ -4,10 +4,12 @@ import pytest
 from pydantic import ValidationError
 
 from mita.config.schema import (
+    PERMISSION_MODE_TOOLS,
     IndexSettings,
     MitaConfig,
     ModelSettings,
     OllamaSettings,
+    PermissionMode,
     PluginDefinition,
     ToolSettings,
 )
@@ -96,3 +98,55 @@ class TestValidators:
     def test_max_iterations_positive(self) -> None:
         with pytest.raises(ValidationError, match="max_iterations must be positive"):
             MitaConfig(max_iterations=0)
+
+
+class TestPermissionMode:
+    def test_default_mode_is_ask(self) -> None:
+        settings = ToolSettings()
+        assert settings.permission_mode == PermissionMode.ASK
+
+    def test_effective_auto_approve_ask(self) -> None:
+        settings = ToolSettings(permission_mode=PermissionMode.ASK)
+        effective = settings.effective_auto_approve
+        assert effective == {"file_read", "glob", "grep"}
+
+    def test_effective_auto_approve_auto_edit(self) -> None:
+        settings = ToolSettings(permission_mode=PermissionMode.AUTO_EDIT)
+        effective = settings.effective_auto_approve
+        assert "file_write" in effective
+        assert "file_edit" in effective
+        assert "git" in effective
+        assert "shell" not in effective
+
+    def test_effective_auto_approve_trust(self) -> None:
+        settings = ToolSettings(permission_mode=PermissionMode.TRUST)
+        effective = settings.effective_auto_approve
+        assert "shell" in effective
+        assert "file_write" in effective
+        assert "git" in effective
+
+    def test_effective_merges_config_overrides(self) -> None:
+        """Explicit auto_approve entries are merged with mode defaults."""
+        settings = ToolSettings(
+            permission_mode=PermissionMode.ASK,
+            auto_approve=["file_read", "glob", "grep", "custom_tool"],
+        )
+        effective = settings.effective_auto_approve
+        assert "custom_tool" in effective
+        assert "file_read" in effective
+
+    def test_auto_approve_default_matches_ask_mode(self) -> None:
+        """Default auto_approve list derives from ASK mode — no duplication drift."""
+        settings = ToolSettings()
+        assert set(settings.auto_approve) == set(PERMISSION_MODE_TOOLS[PermissionMode.ASK])
+
+    def test_permission_mode_from_string(self) -> None:
+        settings = ToolSettings(permission_mode="auto_edit")  # type: ignore[arg-type]
+        assert settings.permission_mode == PermissionMode.AUTO_EDIT
+
+    def test_each_mode_is_superset_of_previous(self) -> None:
+        ask = set(PERMISSION_MODE_TOOLS[PermissionMode.ASK])
+        auto_edit = set(PERMISSION_MODE_TOOLS[PermissionMode.AUTO_EDIT])
+        trust = set(PERMISSION_MODE_TOOLS[PermissionMode.TRUST])
+        assert ask.issubset(auto_edit)
+        assert auto_edit.issubset(trust)

--- a/tests/test_tools/test_executor.py
+++ b/tests/test_tools/test_executor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from mita.config.schema import ToolSettings
+from mita.config.schema import PermissionMode, ToolSettings
 from mita.tools.executor import execute_tool
 from mita.tools.registry import ToolRegistry
 from mita.tools.schema import ToolCall, ToolDefinition, ToolResult
@@ -106,3 +106,66 @@ class TestExecuteTool:
         call = ToolCall(id="1", name="git", arguments={"subcommand": "status"})
         result = await execute_tool(call, registry, ToolSettings())
         assert result.success is True
+
+    @pytest.mark.asyncio()
+    async def test_auto_edit_mode_approves_writes(self, registry: ToolRegistry) -> None:
+        call = ToolCall(id="1", name="danger_tool", arguments={})
+        settings = ToolSettings(
+            permission_mode=PermissionMode.AUTO_EDIT,
+            auto_approve=["danger_tool"],
+        )
+        result = await execute_tool(call, registry, settings)
+        assert result.success is True
+
+    @pytest.mark.asyncio()
+    async def test_trust_mode_approves_shell(self, registry: ToolRegistry) -> None:
+        call = ToolCall(id="1", name="shell", arguments={"command": "echo hello"})
+        settings = ToolSettings(permission_mode=PermissionMode.TRUST)
+        result = await execute_tool(call, registry, settings)
+        assert result.success is True
+
+    @pytest.mark.asyncio()
+    async def test_session_approved_skips_confirm(self, registry: ToolRegistry) -> None:
+        call = ToolCall(id="1", name="danger_tool", arguments={})
+        result = await execute_tool(
+            call, registry, ToolSettings(), session_approved={"danger_tool"}
+        )
+        assert result.success is True
+
+    @pytest.mark.asyncio()
+    async def test_glob_receives_config_max_results(self, registry: ToolRegistry) -> None:
+        """Executor injects _max_results from config into glob args."""
+        captured_args: dict[str, object] = {}
+
+        async def capture_handler(args: dict[str, object]) -> ToolResult:
+            captured_args.update(args)
+            return ToolResult(tool_call_id="", success=True, output="ok")
+
+        reg = ToolRegistry()
+        reg.register(
+            ToolDefinition(name="glob", description="glob", parameters=[], destructive=False),
+            capture_handler,
+        )
+        call = ToolCall(id="1", name="glob", arguments={"pattern": "*.py"})
+        settings = ToolSettings(glob_max_results=42)
+        await execute_tool(call, reg, settings)
+        assert captured_args.get("_max_results") == 42
+
+    @pytest.mark.asyncio()
+    async def test_grep_receives_config_max_matches(self, registry: ToolRegistry) -> None:
+        """Executor injects _max_matches from config into grep args."""
+        captured_args: dict[str, object] = {}
+
+        async def capture_handler(args: dict[str, object]) -> ToolResult:
+            captured_args.update(args)
+            return ToolResult(tool_call_id="", success=True, output="ok")
+
+        reg = ToolRegistry()
+        reg.register(
+            ToolDefinition(name="grep", description="grep", parameters=[], destructive=False),
+            capture_handler,
+        )
+        call = ToolCall(id="1", name="grep", arguments={"pattern": "test"})
+        settings = ToolSettings(grep_max_matches=99)
+        await execute_tool(call, reg, settings)
+        assert captured_args.get("_max_matches") == 99

--- a/tests/test_tools/test_grep.py
+++ b/tests/test_tools/test_grep.py
@@ -7,7 +7,8 @@ from unittest.mock import patch
 
 import pytest
 
-from mita.tools.builtins.grep_tool import MAX_MATCHES, execute
+from mita.tools.builtins.grep_tool import DEFAULT_MAX_MATCHES as MAX_MATCHES
+from mita.tools.builtins.grep_tool import execute
 
 
 class TestGrepTool:

--- a/tests/test_tools/test_safety.py
+++ b/tests/test_tools/test_safety.py
@@ -157,6 +157,67 @@ class TestNeedsConfirmation:
         tool_def = ToolDefinition(name="git", description="git", parameters=[], destructive=False)
         assert needs_confirmation(call, tool_def, settings) is False
 
+    @pytest.mark.parametrize("subcmd", ["status", "diff", "log --oneline", "show", "branch"])
+    def test_git_read_only_commands_skip_confirm(self, subcmd: str) -> None:
+        """Read-only git subcommands should not require confirmation (#58)."""
+        settings = ToolSettings()
+        call = ToolCall(id="1", name="git", arguments={"subcommand": subcmd})
+        tool_def = ToolDefinition(name="git", description="git", parameters=[], destructive=False)
+        assert needs_confirmation(call, tool_def, settings) is False
+
+    def test_auto_edit_mode_approves_writes(self) -> None:
+        """In auto_edit mode, file_write should not require confirmation."""
+        from mita.config.schema import PermissionMode
+
+        settings = ToolSettings(permission_mode=PermissionMode.AUTO_EDIT)
+        call = self._make_call(name="file_write")
+        tool_def = self._make_tool_def(destructive=True)
+        assert needs_confirmation(call, tool_def, settings) is False
+
+    def test_auto_edit_mode_still_confirms_shell(self) -> None:
+        """In auto_edit mode, shell should still require confirmation."""
+        from mita.config.schema import PermissionMode
+
+        settings = ToolSettings(permission_mode=PermissionMode.AUTO_EDIT)
+        call = ToolCall(id="1", name="shell", arguments={"command": "rm -rf /tmp"})
+        tool_def = ToolDefinition(
+            name="shell", description="shell", parameters=[], destructive=True
+        )
+        assert needs_confirmation(call, tool_def, settings) is True
+
+    def test_trust_mode_approves_everything(self) -> None:
+        """In trust mode, even destructive shell commands should be auto-approved."""
+        from mita.config.schema import PermissionMode
+
+        settings = ToolSettings(permission_mode=PermissionMode.TRUST)
+        call = ToolCall(id="1", name="shell", arguments={"command": "rm -rf /"})
+        tool_def = ToolDefinition(
+            name="shell", description="shell", parameters=[], destructive=True
+        )
+        assert needs_confirmation(call, tool_def, settings) is False
+
+    def test_session_approved_skips_confirm(self) -> None:
+        """Tools in session_approved set should skip confirmation."""
+        settings = ToolSettings()
+        call = self._make_call(name="file_write")
+        tool_def = self._make_tool_def(destructive=True)
+        result = needs_confirmation(call, tool_def, settings, session_approved={"file_write"})
+        assert result is False
+
+    def test_session_approved_does_not_affect_other_tools(self) -> None:
+        """Session approval for one tool should not approve another."""
+        settings = ToolSettings()
+        call = self._make_call(name="danger_tool")
+        tool_def = self._make_tool_def(destructive=True)
+        assert needs_confirmation(call, tool_def, settings, session_approved={"file_write"}) is True
+
+    def test_session_approved_none_has_no_effect(self) -> None:
+        """Passing session_approved=None should behave like no session approvals."""
+        settings = ToolSettings()
+        call = self._make_call(name="file_write")
+        tool_def = self._make_tool_def(destructive=True)
+        assert needs_confirmation(call, tool_def, settings, session_approved=None) is True
+
 
 class TestIsGitCommandDestructive:
     @pytest.mark.parametrize(

--- a/tests/test_tools/test_safety.py
+++ b/tests/test_tools/test_safety.py
@@ -157,13 +157,22 @@ class TestNeedsConfirmation:
         tool_def = ToolDefinition(name="git", description="git", parameters=[], destructive=False)
         assert needs_confirmation(call, tool_def, settings) is False
 
-    @pytest.mark.parametrize("subcmd", ["status", "diff", "log --oneline", "show", "branch"])
+    @pytest.mark.parametrize("subcmd", ["status", "diff", "log --oneline", "show", "branch --list"])
     def test_git_read_only_commands_skip_confirm(self, subcmd: str) -> None:
         """Read-only git subcommands should not require confirmation (#58)."""
         settings = ToolSettings()
         call = ToolCall(id="1", name="git", arguments={"subcommand": subcmd})
         tool_def = ToolDefinition(name="git", description="git", parameters=[], destructive=False)
         assert needs_confirmation(call, tool_def, settings) is False
+
+    @pytest.mark.parametrize("subcmd", ["branch -D feature", "branch -d feature"])
+    def test_git_destructive_branch_still_confirms(self, subcmd: str) -> None:
+        """Destructive branch commands must require confirmation even though
+        'branch' is in SAFE_SUBCOMMANDS — destructive check runs first."""
+        settings = ToolSettings()
+        call = ToolCall(id="1", name="git", arguments={"subcommand": subcmd})
+        tool_def = ToolDefinition(name="git", description="git", parameters=[], destructive=False)
+        assert needs_confirmation(call, tool_def, settings) is True
 
     def test_auto_edit_mode_approves_writes(self) -> None:
         """In auto_edit mode, file_write should not require confirmation."""


### PR DESCRIPTION
## Summary

Addresses 5 issues:

- **#71 — Permission modes**: Add `PermissionMode` enum (`ask`, `auto_edit`, `trust`) to config schema with `--permission`/`-p` CLI flag. Each mode defines which tools are auto-approved. `effective_auto_approve` merges mode defaults with config overrides. Session-level approval set threaded through executor.
- **#54 — Agent loop error handling**: Add catch-all `Exception` handler so unexpected errors (hook failures, attribute errors) log and break gracefully instead of crashing the REPL.
- **#57 — Config plumbed to tools**: `glob_max_results` and `grep_max_matches` from `ToolSettings` now injected into tool args by the executor, replacing hardcoded constants.
- **#58 — Safe git commands skip confirmation**: `needs_confirmation` now calls `is_safe_git_command()`, so read-only commands (status, diff, log) don't prompt.
- **#50 — locals().get()**: Already fixed in prior PR (verified).

Also fixes #60 (`confirm_fn` typed as `object` → proper `Callable`).

## Test plan

- [x] 646 tests pass at 87% coverage
- [x] Ruff lint and format clean
- [ ] Manual: `mita chat -p trust` auto-approves all tools
- [ ] Manual: `mita chat -p ask` prompts for everything except reads
- [ ] Manual: `git status` runs without confirmation prompt

Closes #71, #54, #57, #58, #50, #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)